### PR TITLE
Small fix for installation problems under Win 64bit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,9 +48,9 @@ class ve_build_ext(build_ext):
             build_ext.build_extension(self, ext)
         except ext_errors:
             raise BuildFailed()
-        except ValueError, err:
-            # may happen on Win 64 bit, see Python issue7511
-            if "'path'" in str(err):
+        except ValueError:
+            # this can happen on Windows 64 bit, see Python issue 7511
+            if "'path'" in str(sys.exc_info()[1]): # works with Python 2 and 3
                 raise BuildFailed()
             raise
 


### PR DESCRIPTION
I have noticed several times that Windows installations of Python packages failed because they had MarkupSafe as dependency, but there were no Windows binaries for MarkupSafe on PyPI, and the Windows machine had no compiler installed.

Actually this should not happen because you made provisions in the setup.py file to silently ignore a missing compiler and skip compiling the extension in this case, but this never worked on any of my machines, because they always throw a ValueError instead of one of the exceptions you are catching in the setup.py file (see http://bugs.python.org/issue7511 - seems to happen on 64 bit Win only). So I suggest catching this ValueError in addition to the other exceptions.

I can also create Win 32 and 64bit eggs for Py 2.6 and 2.7 for uploading to PyPi if you like.
