### PR TITLE
idempotent unescape

### DIFF
--- a/markupsafe/__init__.py
+++ b/markupsafe/__init__.py
@@ -92,7 +92,7 @@ class Markup(unicode):
 
     def __mod__(self, arg):
         if isinstance(arg, tuple):
-            arg = tuple(imap(_MarkupEscapeHelper, arg, self.escape))
+            arg = tuple(_MarkupEscapeHelper(x, self.escape) for x in arg)
         else:
             arg = _MarkupEscapeHelper(arg, self.escape)
         return self.__class__(unicode.__mod__(self, arg))
@@ -168,7 +168,7 @@ class Markup(unicode):
         orig = getattr(unicode, name)
         def func(self, *args, **kwargs):
             args = _escape_argspec(list(args), enumerate(args), self.escape)
-            #_escape_argspec(kwargs, kwargs.iteritems(), None)
+            _escape_argspec(kwargs, kwargs.iteritems(), self.escape)
             return self.__class__(orig(self, *args, **kwargs))
         func.__name__ = orig.__name__
         func.__doc__ = orig.__doc__

--- a/markupsafe/tests.py
+++ b/markupsafe/tests.py
@@ -19,9 +19,6 @@ class MarkupTestCase(unittest.TestCase):
             'username': '<bad user>'
         } == '<em>&lt;bad user&gt;</em>'
 
-        assert Markup('%i') % 3.14 == '3'
-        assert Markup('%.2f') % 3.14 == '3.14'
-
         # an escaped object is markup too
         assert type(Markup('foo') + 'bar') is Markup
 
@@ -56,6 +53,14 @@ class MarkupTestCase(unittest.TestCase):
         twice = Markup(once).unescape()
         expected = "&foo;"
         assert expected == once == twice, (once, twice)
+
+    def test_formatting(self):
+        assert Markup('%i') % 3.14 == '3'
+        assert Markup('%.2f') % 3.14159 == '3.14'
+        assert Markup('%s %s %s') % ('<',123,'>') == '&lt; 123 &gt;'
+        assert Markup('<em>{awesome}</em>').format(awesome='<awesome>') == \
+                '<em>&lt;awesome&gt;</em>'
+
 
     def test_all_set(self):
         import markupsafe as markup


### PR DESCRIPTION
If we examine the XML spec for entities, we find that ampersand and
space are not allowed characters in an entity name. I've also modified
the unescape function to not modify unexpected inputs (such as &foo;).
This is a common best practice when dealing with layered systems.

http://www.w3.org/TR/REC-xml/#sec-references

EntityRef   ::=   '&' Name ';'
Name   ::=   NameStartChar (NameChar)*
NameChar   ::=   NameStartChar | "-" | "." | [0-9] | #xB7 | [#x0300-#x036F] | [#x203F-#x2040]
NameStartChar   ::=   ":" | [A-Z] | "_" | [a-z] | [#xC0-#xD6] | [#xD8-#xF6] | [#xF8-#x2FF] | [#x370-#x37D] | [#x37F-#x1FFF] | [#x200C-#x200D] | [#x2070-#x218F] | [#x2C00-#x2FEF] | [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]
