### PR TITLE
Fixed format for keyword arguments

### DIFF
--- a/markupsafe/__init__.py
+++ b/markupsafe/__init__.py
@@ -66,7 +66,7 @@ class Markup(text_type):
     """
     __slots__ = ()
 
-    def __new__(cls, base='', encoding=None, errors='strict'):
+    def __new__(cls, base=u'', encoding=None, errors='strict'):
         if hasattr(base, '__html__'):
             base = base.__html__()
         if encoding is None:
@@ -140,7 +140,7 @@ class Markup(text_type):
                     return unichr(int(name[1:]))
             except ValueError:
                 pass
-            return ''
+            return u''
         return _entity_re.sub(handle_match, text_type(self))
 
     def striptags(self):
@@ -151,7 +151,7 @@ class Markup(text_type):
         >>> Markup("Main &raquo;  <em>About</em>").striptags()
         u'Main \xbb About'
         """
-        stripped = ' '.join(_striptags_re.sub('', self).split())
+        stripped = u' '.join(_striptags_re.sub('', self).split())
         return Markup(stripped).unescape()
 
     @classmethod

--- a/markupsafe/tests.py
+++ b/markupsafe/tests.py
@@ -49,28 +49,28 @@ class MarkupTestCase(unittest.TestCase):
         self.assertEqual(Markup('<em>%s:%s</em>') % (
             '<foo>',
             '<bar>',
-        ), Markup('<em>&lt;foo&gt;:&lt;bar&gt;</em>'))
+        ), Markup(u'<em>&lt;foo&gt;:&lt;bar&gt;</em>'))
 
     def test_dict_interpol(self):
         self.assertEqual(Markup('<em>%(foo)s</em>') % {
             'foo': '<foo>',
-        }, Markup('<em>&lt;foo&gt;</em>'))
+        }, Markup(u'<em>&lt;foo&gt;</em>'))
         self.assertEqual(Markup('<em>%(foo)s:%(bar)s</em>') % {
             'foo': '<foo>',
             'bar': '<bar>',
-        }, Markup('<em>&lt;foo&gt;:&lt;bar&gt;</em>'))
+        }, Markup(u'<em>&lt;foo&gt;:&lt;bar&gt;</em>'))
 
     def test_format_args(self):
         self.assertTrue(isinstance(Markup('{0}').format(1), Markup))
         self.assertEqual(Markup('<em>{0:X}:{1:1.2f}</em>').format(
             15,
             0.9999,
-        ), Markup('<em>F:1.00</em>'))
+        ), Markup(u'<em>F:1.00</em>'))
         
         self.assertEqual(Markup('<em>{0}:{1}</em>').format(
             '<foo>',
             Markup('<bar>'),
-        ), Markup('<em>&lt;foo&gt;:<bar></em>'))
+        ), Markup(u'<em>&lt;foo&gt;:<bar></em>'))
 
         # positional argument specifiers can be ommited
         # in Python 2.7 and later
@@ -78,13 +78,13 @@ class MarkupTestCase(unittest.TestCase):
             self.assertEqual(Markup('<em>{}:{}</em>').format(
                 '<foo>',
                 Markup('<bar>'),
-            ), Markup('<em>&lt;foo&gt;:<bar></em>'))
+            ), Markup(u'<em>&lt;foo&gt;:<bar></em>'))
 
     def test_format_kwargs(self):
         self.assertEqual(Markup('<em>{foo}:{bar}</em>').format(
             foo='<foo>',
             bar=Markup('<bar>'),
-        ), Markup('<em>&lt;foo&gt;:<bar></em>'))
+        ), Markup(u'<em>&lt;foo&gt;:<bar></em>'))
 
         class Bar(object):
             def __init__(self, bar):
@@ -93,7 +93,7 @@ class MarkupTestCase(unittest.TestCase):
         self.assertEqual(Markup('<em>{foo[0][foo]}:{bar.bar}</em>').format(
             foo=[{'foo': '<foo>'}],
             bar=Bar(Markup('<bar>')),
-        ), Markup('<em>&lt;foo&gt;:<bar></em>'))
+        ), Markup(u'<em>&lt;foo&gt;:<bar></em>'))
         
     def test_escaping(self):
         # escaping and unescaping
@@ -109,7 +109,7 @@ class MarkupTestCase(unittest.TestCase):
     def test_escape_silent(self):
         assert escape_silent(None) == Markup()
         assert escape(None) == Markup(None)
-        assert escape_silent('<foo>') == Markup('&lt;foo&gt;')
+        assert escape_silent('<foo>') == Markup(u'&lt;foo&gt;')
 
     def test_splitting(self):
         self.assertEqual(Markup('a b').split(), [
@@ -137,8 +137,8 @@ class MarkupLeakTestCase(unittest.TestCase):
             for item in range(1000):
                 escape("foo")
                 escape("<foo>")
-                escape("foo")
-                escape("<foo>")
+                escape(u"foo")
+                escape(u"<foo>")
             counts.add(len(gc.get_objects()))
         assert len(counts) == 1, 'ouch, c extension seems to leak objects'
 


### PR DESCRIPTION
``` python
In [1]: from markupsafe import Markup                                                                                                            

In [2]: Markup(u'{a}').format(a=u'<>')
Out[2]: Markup(u'<>')

In [3]: Markup(u'{}').format(u'<>')                                                                                                             
Out[3]: Markup(u'&lt;&gt;')
```
