### PR TITLE
Drop Python 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: python
 python:
-  - "2.6"
   - "2.7"
   - pypy
   - "3.3"

--- a/README.rst
+++ b/README.rst
@@ -67,10 +67,10 @@ object, you can create your own subclass that does that:
 New-Style String Formatting
 ---------------------------
 
-Starting with MarkupSafe 0.21 new style string formats from Python 2.6 and
-3.x are now fully supported.  Previously the escape behavior of those
-functions was spotty at best.  The new implementations operates under the
-following algorithm:
+Starting with MarkupSafe 0.21 new style string formats from Python 3.x are
+now fully supported.  Previously the escape behavior of those functions
+was spotty at best.  The new implementations operates under the following
+algorithm:
 
 1.  if an object has an ``__html_format__`` method it is called as
     replacement for ``__format__`` with the format specifier.  It either
@@ -110,4 +110,4 @@ And to format that user:
     >>> Markup('<p>User: {0:link}').format(user)
     Markup(u'<p>User: <a href="/user/1"><span class=user>foo</span></a>')
 
-Markupsafe supports Python 2.6, 2.7 and Python 3.3 and higher.
+Markupsafe supports Python 2.7 and Python 3.3 and higher.

--- a/markupsafe/__init__.py
+++ b/markupsafe/__init__.py
@@ -185,28 +185,24 @@ class Markup(text_type):
                   'translate', 'expandtabs', 'swapcase', 'zfill':
         locals()[method] = make_simple_escaping_wrapper(method)
 
-    # new in python 2.5
-    if hasattr(text_type, 'partition'):
-        def partition(self, sep):
-            return tuple(map(self.__class__,
-                             text_type.partition(self, self.escape(sep))))
-        def rpartition(self, sep):
-            return tuple(map(self.__class__,
-                             text_type.rpartition(self, self.escape(sep))))
+    def partition(self, sep):
+        return tuple(map(self.__class__,
+                            text_type.partition(self, self.escape(sep))))
+    def rpartition(self, sep):
+        return tuple(map(self.__class__,
+                            text_type.rpartition(self, self.escape(sep))))
 
-    # new in python 2.6
-    if hasattr(text_type, 'format'):
-        def format(*args, **kwargs):
-            self, args = args[0], args[1:]
-            formatter = EscapeFormatter(self.escape)
-            kwargs = _MagicFormatMapping(args, kwargs)
-            return self.__class__(formatter.vformat(self, args, kwargs))
+    def format(*args, **kwargs):
+        self, args = args[0], args[1:]
+        formatter = EscapeFormatter(self.escape)
+        kwargs = _MagicFormatMapping(args, kwargs)
+        return self.__class__(formatter.vformat(self, args, kwargs))
 
-        def __html_format__(self, format_spec):
-            if format_spec:
-                raise ValueError('Unsupported format specification '
-                                 'for Markup.')
-            return self
+    def __html_format__(self, format_spec):
+        if format_spec:
+            raise ValueError('Unsupported format specification '
+                                'for Markup.')
+        return self
 
     # not in python 3
     if hasattr(text_type, '__getslice__'):

--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,6 @@ speedups = Feature(
 
 # Known errors when running build_ext.build_extension method
 ext_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError)
-if sys.platform == 'win32' and sys.version_info > (2, 6):
-    # 2.6's distutils.msvc9compiler can raise an IOError when failing to
-    # find the compiler
-    ext_errors += (IOError,)
 # Known errors when running build_ext.run method
 run_errors = (DistutilsPlatformError,)
 if sys.platform == 'darwin':

--- a/tests.py
+++ b/tests.py
@@ -92,11 +92,9 @@ class MarkupTestCase(unittest.TestCase):
              '<bar/>')):
             assert actual == expected, "%r should be %r!" % (actual, expected)
 
-    # This is new in 2.7
-    if sys.version_info >= (2, 7):
-        def test_formatting_empty(self):
-            formatted = Markup('{}').format(0)
-            assert formatted == Markup('0')
+    def test_formatting_empty(self):
+        formatted = Markup('{}').format(0)
+        assert formatted == Markup('0')
 
     def test_custom_formatting(self):
         class HasHTMLOnly(object):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,pypy,py33,py34,py35
+envlist = py27,pypy,py33,py34,py35
 
 [testenv]
 commands = py.test tests.py {posargs}


### PR DESCRIPTION
Yesterday marks 3 years since the last release of Python 2.6! 🎉

To celebrate, I'm attempting to drop support for it from 156 prominent Python packages (one for every week it's past end-of-life)--including this one!

I've tried my best to remove as much 2.6-specific cruft as I can, but at the very least, this PR will remove the `'Programming Language :: Python :: 2.6'` trove classifier from this projects `setup.py`.
