### PR TITLE
Add Appveyor script for building Windows wheels

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,12 +9,15 @@ environment:
   # See http://stackoverflow.com/a/9407178/1354930
   global:
     PIP: "pip"
+    TOX: "tox"
 
   matrix:
-#    - PYTHON: "C:\\Python26"
-#      PIP: "pip.__main__"
-#    - PYTHON: "C:\\Python26-x64"
-#      PIP: "pip.__main__"
+    - PYTHON: "C:\\Python26"
+      PIP: "pip.__main__"
+      TOX: "tox.__main__"
+    - PYTHON: "C:\\Python26-x64"
+      PIP: "pip.__main__"
+      TOX: "tox.__main__"
     - PYTHON: "C:\\Python27"
     - PYTHON: "C:\\Python27-x64"
     - PYTHON: "C:\\Python33"
@@ -39,7 +42,7 @@ build: off  # Not a C# project, build stuff at the test step instead.
 
 test_script:
   # Run the project tests
-  - "%PYTHON%\\python.exe -m tox -e py"
+  - "%PYTHON%\\python.exe -m %TOX% -e py"
 
 after_test:
   # if tests OK, create whl package

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,7 +59,7 @@ artifacts:
 #deploy:
 #  - provider: GitHub
 #    auth_token:
-#      secure: <your encrypted token>    # encrypoted github token
+#      secure: <your encrypted token>    # encrypted github token
 #    release: $APPVEYOR_REPO_TAG_NAME
 #    artifact: /.*\.whl/                 # upload all the wheels.
 #    draft: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,66 @@
+### ----------------------
+### General Configuration
+### ----------------------
+
+environment:
+  # Set a global environment variable that points to the `pip` command.
+  # The Python26 builds overwrite this variable because it needs
+  # `python -m module.__main__` rather than just `python -m module`.
+  # See http://stackoverflow.com/a/9407178/1354930
+  global:
+    PIP: "pip"
+
+  matrix:
+#    - PYTHON: "C:\\Python26"
+#      PIP: "pip.__main__"
+#    - PYTHON: "C:\\Python26-x64"
+#      PIP: "pip.__main__"
+    - PYTHON: "C:\\Python27"
+    - PYTHON: "C:\\Python27-x64"
+    - PYTHON: "C:\\Python33"
+    - PYTHON: "C:\\Python33-x64"
+    - PYTHON: "C:\\Python34"
+    - PYTHON: "C:\\Python34-x64"
+    - PYTHON: "C:\\Python35"
+    - PYTHON: "C:\\Python35-x64"
+    - PYTHON: "C:\\Python36"
+    - PYTHON: "C:\\Python36-x64"
+
+install:
+  # Check that we have the expected version and architecture for Python
+  - "%PYTHON%\\python.exe --version"
+
+  # install dependencies
+
+  - "%PYTHON%\\python.exe -m %PIP% install --upgrade pip wheel"
+  - "%PYTHON%\\python.exe -m %PIP% install tox"
+
+build: off  # Not a C# project, build stuff at the test step instead.
+
+test_script:
+  # Run the project tests
+  - "%PYTHON%\\python.exe -m tox -e py"
+
+after_test:
+  # if tests OK, create whl package
+  - "%PYTHON%\\python.exe setup.py bdist_wheel"
+
+artifacts:
+  # Upload the wheel and EXE to AppVeyor
+  - path: dist\*.whl
+    type: whl
+
+# This is left to the package maintainer to update with the secure tokens.
+# See https://www.appveyor.com/docs/deployment/github/
+# and https://www.appveyor.com/docs/build-configuration/#secure-variables
+#deploy:
+#  - provider: GitHub
+#    auth_token:
+#      secure: <your encrypted token>    # encrypoted github token
+#    release: $APPVEYOR_REPO_TAG_NAME
+#    artifact: /.*\.whl/                 # upload all the wheels.
+#    draft: false
+#    prerelease: false
+#    on:
+#      branch: master                    # release from master branch only
+#      appveyor_repo_tag: true           # deploy only on tags


### PR DESCRIPTION
This adds Appveyor CI for building Windows wheels. 

+ PyPy is *not* built because Appveyor doesn't come with PyPy pre-installed and I didn't want to figure out how to add it.
+ A stub for releasing to GitHub is included but commented out, as it will require the repo maintainer to generate a token and then secure it in Appveyor.
+ Wheel artifacts are made for every build and uploaded to Appveyor. It's out of scope of this PR to auto-upload them to PyPI.
+ Addresses #45, though I'm not sure if this PR actually closes it.