### PR TITLE
Fix the return type of escape to Markup

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,16 @@
 MarkupSafe Changelog
 ====================
 
+Version 1.1
+-----------
+
+unreleased
+
+- ``escape`` wraps ``__html__`` result in ``Markup``, consistent with
+  documented behavior. (`#69`_)
+
+.. _#69: https://github.com/pallets/markupsafe/pull/69
+
 Version 1.0
 -----------
 

--- a/markupsafe/_native.py
+++ b/markupsafe/_native.py
@@ -18,7 +18,7 @@ def escape(s):
     such characters in HTML.  Marks return value as markup string.
     """
     if hasattr(s, '__html__'):
-        return s.__html__()
+        return Markup(s.__html__())
     return Markup(text_type(s)
         .replace('&', '&amp;')
         .replace('>', '&gt;')

--- a/markupsafe/_speedups.c
+++ b/markupsafe/_speedups.c
@@ -131,8 +131,11 @@ escape(PyObject *self, PyObject *text)
 	/* if the object has an __html__ method that performs the escaping */
 	html = PyObject_GetAttrString(text, "__html__");
 	if (html) {
-		rv = PyObject_CallObject(html, NULL);
+		s = PyObject_CallObject(html, NULL);
 		Py_DECREF(html);
+		/* Convert to Markup object */
+		rv = PyObject_CallFunctionObjArgs(markup, (PyObject*)s, NULL);
+		Py_DECREF(s);
 		return rv;
 	}
 

--- a/tests.py
+++ b/tests.py
@@ -173,6 +173,14 @@ class MarkupTestCase(unittest.TestCase):
     def test_mul(self):
         self.assertEqual(Markup('a') * 3, Markup('aaa'))
 
+    def test_escape_return_type(self):
+        self.assertIsInstance(escape('a'), Markup)
+        self.assertIsInstance(escape(Markup('a')), Markup)
+        class Foo:
+            def __html__(self):
+                return '<strong>Foo</strong>'
+        self.assertIsInstance(escape(Foo()), Markup)
+
 
 class MarkupLeakTestCase(unittest.TestCase):
 

--- a/tests.py
+++ b/tests.py
@@ -174,12 +174,12 @@ class MarkupTestCase(unittest.TestCase):
         self.assertEqual(Markup('a') * 3, Markup('aaa'))
 
     def test_escape_return_type(self):
-        self.assertIsInstance(escape('a'), Markup)
-        self.assertIsInstance(escape(Markup('a')), Markup)
+        self.assertTrue(isinstance(escape('a'), Markup))
+        self.assertTrue(isinstance(escape(Markup('a')), Markup))
         class Foo:
             def __html__(self):
                 return '<strong>Foo</strong>'
-        self.assertIsInstance(escape(Foo()), Markup)
+        self.assertTrue(isinstance(escape(Foo()), Markup))
 
 
 class MarkupLeakTestCase(unittest.TestCase):


### PR DESCRIPTION
This patch fixes the return type of `escape` to always be a `Markup`. It
addresses the issue with custom class that implements the `__html__`
method - see issue #68. A new test case, `test_escape_return_type`, is
added to test the behavior.