### PR TITLE
new functionality to handle ascii backspace

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,9 @@ Version 1.1
 
 unreleased
 
+- The ascii control character `\b` is now escaped to the raw string "\b" by
+  ``escape``, and it is removed by ``Markup.striptags``.
+
 - ``escape`` wraps ``__html__`` result in ``Markup``, consistent with
   documented behavior. (`#69`_)
 

--- a/markupsafe/__init__.py
+++ b/markupsafe/__init__.py
@@ -156,7 +156,7 @@ class Markup(text_type):
         u'Main \xbb About'
         """
         stripped = u' '.join(_striptags_re.sub('', self).split())
-        return Markup(stripped).unescape()
+        return Markup(stripped).unescape().replace('\b', '')
 
     @classmethod
     def escape(cls, s):

--- a/markupsafe/_native.py
+++ b/markupsafe/_native.py
@@ -25,6 +25,7 @@ def escape(s):
         .replace('<', '&lt;')
         .replace("'", '&#39;')
         .replace('"', '&#34;')
+        .replace('\b', r'\b')
     )
 
 

--- a/markupsafe/_speedups.c
+++ b/markupsafe/_speedups.c
@@ -35,12 +35,14 @@ init_constants(void)
 	escaped_chars_repl['&'] = UNICHR("&amp;");
 	escaped_chars_repl['<'] = UNICHR("&lt;");
 	escaped_chars_repl['>'] = UNICHR("&gt;");
+	escaped_chars_repl['\b'] = UNICHR("\\b");
 
 	/* lengths of those characters when replaced - 1 */
 	memset(escaped_chars_delta_len, 0, sizeof (escaped_chars_delta_len));
 	escaped_chars_delta_len['"'] = escaped_chars_delta_len['\''] = \
 		escaped_chars_delta_len['&'] = 4;
 	escaped_chars_delta_len['<'] = escaped_chars_delta_len['>'] = 3;
+	escaped_chars_delta_len['\b'] = escaped_chars_delta_len[8] = 1;
 
 	/* import markup type so that we can mark the return value */
 	module = PyImport_ImportModule("markupsafe");

--- a/tests.py
+++ b/tests.py
@@ -64,7 +64,11 @@ class MarkupTestCase(unittest.TestCase):
     def test_escaping(self):
         # escaping
         assert escape('"<>&\'') == '&#34;&lt;&gt;&amp;&#39;'
+        assert escape('"<>&\'\b') == '&#34;&lt;&gt;&amp;&#39;\\b'
+        assert escape('\b') == r'\b'
+        assert escape('\b') == '\\b'
         assert Markup("<em>Foo &amp; Bar</em>").striptags() == "Foo & Bar"
+        assert Markup("<em>Foo &amp; Bar\b</em>").striptags() == r"Foo & Bar"
 
     def test_unescape(self):
         assert Markup("&lt;test&gt;").unescape() == "<test>"


### PR DESCRIPTION
This is a suggestion for #71 

* The ASCII control character for backspace (`\b`) is unescaped into it's raw string representation`r'\b' == '\\b'` by `unescape`
* The ASCII control character for backspace (`\b`) is deleted by `Markup.striptags()`