### PR TITLE
Remove Python <= 2.5 code

### DIFF
--- a/markupsafe/__init__.py
+++ b/markupsafe/__init__.py
@@ -185,14 +185,12 @@ class Markup(text_type):
                   'translate', 'expandtabs', 'swapcase', 'zfill':
         locals()[method] = make_simple_escaping_wrapper(method)
 
-    # new in python 2.5
-    if hasattr(text_type, 'partition'):
-        def partition(self, sep):
-            return tuple(map(self.__class__,
-                             text_type.partition(self, self.escape(sep))))
-        def rpartition(self, sep):
-            return tuple(map(self.__class__,
-                             text_type.rpartition(self, self.escape(sep))))
+    def partition(self, sep):
+        return tuple(map(self.__class__,
+                         text_type.partition(self, self.escape(sep))))
+    def rpartition(self, sep):
+        return tuple(map(self.__class__,
+                         text_type.rpartition(self, self.escape(sep))))
 
     # new in python 2.6
     if hasattr(text_type, 'format'):

--- a/markupsafe/__init__.py
+++ b/markupsafe/__init__.py
@@ -188,17 +188,16 @@ class Markup(text_type):
     def partition(self, sep):
         return tuple(map(self.__class__,
                          text_type.partition(self, self.escape(sep))))
+
     def rpartition(self, sep):
         return tuple(map(self.__class__,
                          text_type.rpartition(self, self.escape(sep))))
 
-    # new in python 2.6
-    if hasattr(text_type, 'format'):
-        def format(*args, **kwargs):
-            self, args = args[0], args[1:]
-            formatter = EscapeFormatter(self.escape)
-            kwargs = _MagicFormatMapping(args, kwargs)
-            return self.__class__(formatter.vformat(self, args, kwargs))
+    def format(*args, **kwargs):
+        self, args = args[0], args[1:]
+        formatter = EscapeFormatter(self.escape)
+        kwargs = _MagicFormatMapping(args, kwargs)
+        return self.__class__(formatter.vformat(self, args, kwargs))
 
         def __html_format__(self, format_spec):
             if format_spec:

--- a/markupsafe/_speedups.c
+++ b/markupsafe/_speedups.c
@@ -14,12 +14,6 @@
 #define ESCAPED_CHARS_TABLE_SIZE 63
 #define UNICHR(x) (PyUnicode_AS_UNICODE((PyUnicodeObject*)PyUnicode_DecodeASCII(x, strlen(x), NULL)));
 
-#if PY_VERSION_HEX < 0x02050000 && !defined(PY_SSIZE_T_MIN)
-typedef int Py_ssize_t;
-#define PY_SSIZE_T_MAX INT_MAX
-#define PY_SSIZE_T_MIN INT_MIN
-#endif
-
 
 static PyObject* markup;
 static Py_ssize_t escaped_chars_delta_len[ESCAPED_CHARS_TABLE_SIZE];


### PR DESCRIPTION
From https://github.com/pallets/markupsafe/pull/15#issuecomment-21758817:

> JFTR: 2.5 support is not necessary, if it's still in the library it can be dropped.
