### PR TITLE
Drop unsupported Python 2.6 and 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: python
 python:
-  - "2.6"
   - "2.7"
   - pypy
   - "3.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 python:
   - "2.7"
   - pypy
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/README.rst
+++ b/README.rst
@@ -110,4 +110,4 @@ And to format that user:
     >>> Markup('<p>User: {0:link}').format(user)
     Markup(u'<p>User: <a href="/user/1"><span class=user>foo</span></a>')
 
-Markupsafe supports Python 2.6, 2.7 and Python 3.3 and higher.
+Markupsafe supports Python 2.7 and Python 3.3 and higher.

--- a/README.rst
+++ b/README.rst
@@ -110,4 +110,4 @@ And to format that user:
     >>> Markup('<p>User: {0:link}').format(user)
     Markup(u'<p>User: <a href="/user/1"><span class=user>foo</span></a>')
 
-Markupsafe supports Python 2.7 and Python 3.3 and higher.
+Markupsafe supports Python 2.7 and Python 3.4 and higher.

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,6 @@ def run_setup(with_binary):
             'Programming Language :: Python :: 2',
             'Programming Language :: Python :: 2.7',
             'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.3',
             'Programming Language :: Python :: 3.4',
             'Programming Language :: Python :: 3.5',
             'Programming Language :: Python :: 3.6',

--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,7 @@ speedups = Feature(
 
 # Known errors when running build_ext.build_extension method
 ext_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError)
-if sys.platform == 'win32' and sys.version_info > (2, 6):
-    # 2.6's distutils.msvc9compiler can raise an IOError when failing to
-    # find the compiler
-    ext_errors += (IOError,)
+
 # Known errors when running build_ext.run method
 run_errors = (DistutilsPlatformError,)
 if sys.platform == 'darwin':
@@ -94,7 +91,6 @@ def run_setup(with_binary):
             'Operating System :: OS Independent',
             'Programming Language :: Python',
             'Programming Language :: Python :: 2',
-            'Programming Language :: Python :: 2.6',
             'Programming Language :: Python :: 2.7',
             'Programming Language :: Python :: 3',
             'Programming Language :: Python :: 3.3',

--- a/tests.py
+++ b/tests.py
@@ -92,11 +92,9 @@ class MarkupTestCase(unittest.TestCase):
              '<bar/>')):
             assert actual == expected, "%r should be %r!" % (actual, expected)
 
-    # This is new in 2.7
-    if sys.version_info >= (2, 7):
-        def test_formatting_empty(self):
-            formatted = Markup('{}').format(0)
-            assert formatted == Markup('0')
+    def test_formatting_empty(self):
+        formatted = Markup('{}').format(0)
+        assert formatted == Markup('0')
 
     def test_custom_formatting(self):
         class HasHTMLOnly(object):

--- a/tests.py
+++ b/tests.py
@@ -174,12 +174,12 @@ class MarkupTestCase(unittest.TestCase):
         self.assertEqual(Markup('a') * 3, Markup('aaa'))
 
     def test_escape_return_type(self):
-        self.assertTrue(isinstance(escape('a'), Markup))
-        self.assertTrue(isinstance(escape(Markup('a')), Markup))
+        self.assertIsInstance(escape('a'), Markup)
+        self.assertIsInstance(escape(Markup('a')), Markup)
         class Foo:
             def __html__(self):
                 return '<strong>Foo</strong>'
-        self.assertTrue(isinstance(escape(Foo()), Markup))
+        self.assertIsInstance(escape(Foo()), Markup)
 
 
 class MarkupLeakTestCase(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,pypy,py33,py34,py35,py36
+envlist = py27,pypy,py33,py34,py35,py36
 
 [testenv]
 commands = py.test tests.py {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,pypy,py33,py34,py35,py36
+envlist = py27,pypy,py34,py35,py36
 
 [testenv]
 commands = py.test tests.py {posargs}


### PR DESCRIPTION
## Reasons for dropping old ones

### 2.6

* Unsupported since [2013-10-29](https://en.wikipedia.org/wiki/CPython#Version_history)
* https://snarky.ca/stop-using-python-2-6/
* http://www.curiousefficiency.org/posts/2015/04/stop-supporting-python26.html
* http://www.python3statement.org
* Current pip 9 deprecates Python 2.6 support, pip 10 won't support it (https://github.com/pypa/pip/issues/3955)
* Not much PyPI traffic (June 2016) https://github.com/pypa/pip/issues/3796

### 3.2

* (Already dropped)

### 3.3

* Unsupported since [2017-09-29](https://en.wikipedia.org/wiki/CPython#Version_history)
* pip 10 will deprecate Python 3.3 support, pip 11 won't support it (https://github.com/pypa/pip/issues/3796)
* Very little PyPI traffic (June 2016) https://github.com/pypa/pip/issues/3796
