### PR TITLE
[WIP] fix #94 by using pytest-cov instead of plain coverage

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,9 +7,9 @@ envlist =
 [testenv]
 passenv = LANG
 deps =
-    pytest>=3
     pytest-cov
-commands = pytest --cov=markupsafe {posargs}
+commands = pytest --cov={envsitepackagesdir}/markupsafe --cov-config=tox.ini --cov-report='' --cov-append {posargs}
+
 [testenv:docs-html]
 deps =
     sphinx
@@ -34,3 +34,15 @@ commands =
     coverage combine
     coverage report
     codecov
+
+[coverage:run]
+branch = True
+parallel = True
+source =
+    markupsafe
+
+[coverage:paths]
+source =
+    markupsafe
+    .tox/*/lib/python*/site-packages/markupsafe
+    .tox/pypy/site-packages/markupsafe

--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,8 @@ envlist =
 passenv = LANG
 deps =
     pytest>=3
-    coverage
-commands = coverage run -p -m pytest {posargs}
-
+    pytest-cov
+commands = pytest --cov=markupsafe {posargs}
 [testenv:docs-html]
 deps =
     sphinx


### PR DESCRIPTION
the issue is that `python -m pytest` messes up the pythonpath and the coverage runnign uses it
unfortunately its not yet clear if pytest-cov has the same coverage results