### PR TITLE
Import Mapping from collections.abc

### DIFF
--- a/markupsafe/__init__.py
+++ b/markupsafe/__init__.py
@@ -9,13 +9,11 @@ special characters with safe representations.
 :copyright: © 2010 by the Pallets team.
 :license: BSD, see LICENSE for more details.
 """
-from collections import Mapping
-
 import re
 import string
 
 from markupsafe._compat import (
-    PY2, int_types, iteritems, string_types, text_type, unichr
+    PY2, int_types, iteritems, string_types, text_type, unichr, Mapping
 )
 
 __version__ = '1.1'

--- a/markupsafe/_compat.py
+++ b/markupsafe/_compat.py
@@ -16,9 +16,11 @@ if not PY2:
     unichr = chr
     int_types = (int,)
     iteritems = lambda x: iter(x.items())
+    from collections.abc import Mapping
 else:
     text_type = unicode
     string_types = (str, unicode)
     unichr = unichr
     int_types = (int, long)
     iteritems = lambda x: x.iteritems()
+    from collections import Mapping


### PR DESCRIPTION
In Python 3.7, importing ABCs directly from the `collections` module shows a
warning (and in Python 3.8 it will stop working) - see
https://github.com/python/cpython/commit/c66f9f8d3909f588c251957d499599a1680e2320

This fixes the following `DeprecationWarning`:

```
>>> import warnings
>>> warnings.simplefilter('default')
>>> import markupsafe
.../markupsafe/__init__.py:12: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
  from collections import Mapping
```