### PR TITLE
restore __html_format__ method

### DIFF
--- a/src/markupsafe/__init__.py
+++ b/src/markupsafe/__init__.py
@@ -191,11 +191,11 @@ class Markup(text_type):
         kwargs = _MagicFormatMapping(args, kwargs)
         return self.__class__(formatter.vformat(self, args, kwargs))
 
-        def __html_format__(self, format_spec):
-            if format_spec:
-                raise ValueError('Unsupported format specification '
-                                 'for Markup.')
-            return self
+    def __html_format__(self, format_spec):
+        if format_spec:
+            raise ValueError('Unsupported format specification '
+                             'for Markup.')
+        return self
 
     # not in python 3
     if hasattr(text_type, '__getslice__'):


### PR DESCRIPTION
👋,
I was looking through this package and noticed some unreachable code that looks like it was missed when python 2.5 support was dropped [here](https://github.com/pallets/markupsafe/commit/e50c2699fc3751a922578a9fc248c64b49b19baa#diff-d3c944407b2648f7a54c52916239d94fR202). 

Now I'm not totally sure this code is even needed still. It looks like the `EscapeFormatter` will check for and call it. If it is still needed then perhaps a test is in order.