### PR TITLE
Build wheels

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,8 +18,8 @@ init:
   - SET PATH=%PYTHON%;%PATH%
 
 install:
-  - python -m pip install -IU pip
-  - python -m pip install -IU setuptools wheel tox
+  - python -m pip install -U pip
+  - python -m pip install -U setuptools wheel tox
 
 build: false
 
@@ -27,11 +27,21 @@ test_script:
   - python -m tox --skip-missing-interpreters=false
 
 after_test:
-  - python setup.py release bdist_wheel
+  - python setup.py bdist_wheel
 
 artifacts:
   - path: dist\*.whl
     type: whl
+
+deploy:
+  provider: S3
+  access_key_id:
+    secure: "KP/pEANcoiWbT6ie9cwmMseUN2Z/VZEmcN2kAlA8rdY="
+  secret_access_key:
+    secure: "kaYMEi5krUfR1pKRyXbuL7Lkxwrv6T6qwfhl0bE0BPqKCSOU1REx23OYz97UtAGq"
+  bucket: pallets-wheels
+  region: us-east-1
+  folder: markupsafe
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,41 @@ matrix:
       sudo: required
       python: "3.7"
     - env: TOXENV=docs-html
+    - stage: wheel
+      sudo: required
+      services:
+        - docker
+      install:
+        - pip install cibuildwheel
+      script: &wheel_script
+        - cibuildwheel --output-dir wheelhouse
+      deploy: &wheel_deploy
+        skip_cleanup: true
+        provider: s3
+        access_key_id:
+          secure: "zAF4qUM+MwCDt1NmMYDgHKldcQi+J2OdC/UCLfJLA/HRzIQoulIRKBcy6IEbf4IPaejwrhPtGG2LX9fIVBWsZs/3IyInf9ywSD88IdLPO0FUHcd6ebAsQSYuG2naVC9r0G6dDZzXT8vSf4Q2OxEsdsUg+NZtOmtv45jGlnuHc5Y="
+        secret_access_key:
+          secure: "I6OUM83O0o/N8Zvxk3vI40JDjQKniSUPPyeY5H53I+DtuUfFl0JOYHXr+XKjhM/CCGT3A2lJwugE1YOXch7fc5QRxp30Dl61ASOY3QFRp2EGNPNTBi5l9NYChPSEC96t6LzZJTSqvRmC+STrpinPW03egNKPJbBU8OKYyEyJr+M="
+        bucket: pallets-wheels
+        region: us-east-1
+        local_dir: wheelhouse
+        upload-dir: markupsafe
+    - stage: wheel
+      os: osx
+      language: generic
+      install:
+        - pip2 install cibuildwheel
+      script: *wheel_script
+      deploy: *wheel_deploy
   allow_failures:
     - python: nightly
     - python: pypy3
   fast_finish: true
+
+stages:
+  - test
+  - name: wheel
+    if: NOT type = pull_request
 
 install:
   - pip install tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,6 @@
 [metadata]
 license_file = LICENSE.rst
 
-[egg_info]
-tag_build = dev
-
-[aliases]
-release = egg_info -Db ''
-
 [tool:pytest]
 testpaths = tests
 

--- a/src/markupsafe/__init__.py
+++ b/src/markupsafe/__init__.py
@@ -16,7 +16,7 @@ from markupsafe._compat import (
     PY2, int_types, iteritems, string_types, text_type, unichr, Mapping
 )
 
-__version__ = '1.1'
+__version__ = '1.1.dev'
 
 __all__ = ['Markup', 'soft_unicode', 'escape', 'escape_silent']
 


### PR DESCRIPTION
Build wheels using [cibuildwheel](https://github.com/joerick/cibuildwheel) on Travis for Linux and Mac, and directly on Appveyor for Windows. Files are uploaded to S3 on my AWS account for now.

Closes #45 