### PR TITLE
Add NULL check after native call to __html__ method

### DIFF
--- a/src/markupsafe/_speedups.c
+++ b/src/markupsafe/_speedups.c
@@ -311,6 +311,9 @@ escape(PyObject *self, PyObject *text)
 	if (html) {
 		s = PyObject_CallObject(html, NULL);
 		Py_DECREF(html);
+		if (s == NULL) {
+			return NULL;
+		}
 		/* Convert to Markup object */
 		rv = PyObject_CallFunctionObjArgs(markup, (PyObject*)s, NULL);
 		Py_DECREF(s);

--- a/tests/test_exception_custom_html.py
+++ b/tests/test_exception_custom_html.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from markupsafe import escape
+
+
+class CustomHtmlThatRaises(object):
+    def __html__(self):
+        raise ValueError(123)
+
+
+def test_exception_custom_html():
+    """Checks whether exceptions in custom __html__ implementations are
+    propagated correctly.
+
+    There was a bug in the native implementation at some point:
+    https://github.com/pallets/markupsafe/issues/108
+    """
+    obj = CustomHtmlThatRaises()
+    with pytest.raises(ValueError):
+        escape(obj)


### PR DESCRIPTION
If the method raises an exception, PyObject_CallObject() returns NULL,
but the code didn't check for that, which led to a segfault.

Fixes #108