### PR TITLE
Update Black URL

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: reorder-python-imports
         args: ["--application-directories", "src"]
-  - repo: https://github.com/ambv/black
+  - repo: https://github.com/python/black
     rev: 18.9b0
     hooks:
       - id: black


### PR DESCRIPTION
> Black, your uncompromising #Python code formatter, was a project
> created with the community in mind from Day 1. Today we moved it under
> the PSF umbrella. It's now available on GitHub under
> https://github.com/python/black/ . You install and use it just like
> before.

https://twitter.com/llanga/status/1123980466292445190