### PR TITLE
Add link to official Discord chat server

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,3 +67,4 @@ Links
     *   Windows: https://ci.appveyor.com/project/pallets/markupsafe
 
 *   Test coverage: https://codecov.io/gh/pallets/markupsafe
+*   Official chat: https://discord.gg/t6rrQZH


### PR DESCRIPTION
All Pallets projects should have a link to the official chat server on Discord.