### PR TITLE
use older Windows image for building Python 3.5

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -62,6 +62,10 @@ jobs:
           vmImage: 'ubuntu-latest'
         Windows:
           vmImage: 'windows-latest'
+          CIBW_SKIP: 'cp35-*'
+        Windows Python 3.5:
+          vmImage: 'vs2017-win2016'
+          CIBW_BUILD: 'cp35-*'
         Mac:
           vmImage: 'macos-latest'
 


### PR DESCRIPTION
See joerick/cibuildwheel#254. Building the wheel for Python 3.5 on Windows was having some trouble with the compiler, switching to an older image fixed it.