### PR TITLE
Add travis CI YAML config to build aarch64 artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+dist: bionic
+os: linux
+arch: arm64
+stages:
+- test
+- build
+jobs:
+  include:
+  - stage: test
+    python: 3.6
+    install: pip3 install tox
+    script: tox -e style
+  - python: 3.6
+    install: pip3 install tox
+    script: tox -e docs
+  - python: 3.6
+    install: pip3 install tox
+    script: tox -e py36
+  - python: 3.7
+    install: pip3 install tox
+    script: tox -e py37
+  - python: 3.8
+    install: pip3 install tox
+    script: tox -e py38
+  - python: pypy3
+    install: pip3 install tox
+    script: tox -e pypy3
+  - stage: build
+    services: docker
+    env: CIBW_SKIP="cp27-* pp27-* cp35-*"
+    install:
+    - pip3 install --upgrade cibuildwheel
+    script:
+    - cibuildwheel --output-dir wheelhouse


### PR DESCRIPTION
Travis-ci offers a way to create ARM64 artifacts. Moreover, travis-ci.com will, in the future, provide access to Graviton2 instances to build ARM64 artifacts, greatly reducing build and test times. 

Note: The upload part needs some input from the maintainers since an API token is needed to upload to PyPI.

Travis build log: https://travis-ci.com/github/janaknat/markupsafe/builds/180044079