### PR TITLE
Arm64 testing and wheel builds via docker buildx in github actions

### DIFF
--- a/.github/workflows/Dockerfile_aarch64_build
+++ b/.github/workflows/Dockerfile_aarch64_build
@@ -1,0 +1,11 @@
+FROM quay.io/pypa/manylinux2014_aarch64 as build
+
+ENV PLAT=manylinux2014_aarch64
+RUN mkdir -p /io/
+COPY . /io/
+WORKDIR /io/
+
+RUN ./.github/workflows/build-manylinux-wheels.sh
+
+FROM scratch as release
+COPY --from=build /io/dist /wheelhouse

--- a/.github/workflows/Dockerfile_aarch64_test
+++ b/.github/workflows/Dockerfile_aarch64_test
@@ -1,0 +1,21 @@
+ARG VERSION
+FROM ubuntu:${VERSION}
+
+ARG PYTHON
+ENV PYTHON=${PYTHON}
+
+RUN apt-get -y update
+RUN apt-get install -y python3 python3-pip
+RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install --upgrade setuptools
+# Pypy only available on ubuntu:focal
+RUN if [ "$PYTHON" = "pypy3" ]; then apt-get install -y pypy3; fi
+# python3.7 only available on ubuntu:bionic
+RUN if [ "$PYTHON" = "py37" ]; then apt-get install -y python3.7; fi
+RUN python3 -m pip install tox
+
+RUN mkdir -p /io/
+COPY . /io/
+
+WORKDIR /io/
+RUN tox -e ${PYTHON}

--- a/.github/workflows/build-manylinux-wheels.sh
+++ b/.github/workflows/build-manylinux-wheels.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e -x
+
+#Requires variable PLAT=[docker name] inside the Docker to be defined
+# auditwheel can't detect the Docker name automatically.
+
+mkdir -p /io/temp-wheels
+
+for PYBIN in /opt/python/cp3[6789]*/bin; do
+    "${PYBIN}/pip" install -q -U setuptools
+    (cd /io/ && "${PYBIN}/python" setup.py -q bdist_wheel -d /io/temp-wheels)
+done
+
+"$PYBIN/pip" install -q auditwheel
+
+# Wheels aren't considered manylinux unless they have been through
+# auditwheel. Audited wheels go in /io/dist/.
+mkdir -p /io/dist/
+
+for whl in /io/temp-wheels/*.whl; do
+    auditwheel repair "$whl" --plat $PLAT -w /io/dist/
+done

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,3 +26,27 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse
+
+  wheels_aarch64:
+    name: ${{ matrix.os }}-aarch64
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Docker Buildx
+        id: Buildx
+        uses: crazy-max/ghaction-docker-buildx@v3.3.0
+        with:
+          buildx-version: latest
+          qemu-version: latest
+      - name: Use docker to install and emulate AArch64 tests
+        run: |
+          docker buildx build --platform linux/arm64 -t markupsafe_aarch64 --output tmpwheelhouse -f .github/workflows/Dockerfile_aarch64_build .
+          mkdir -p wheelhouse
+          mv tmpwheelhouse/wheelhouse/*.whl wheelhouse/
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -50,3 +50,28 @@ jobs:
         if: matrix.tox == 'style'
       - run: pip install tox
       - run: tox -e ${{ matrix.tox }}
+
+  tests_aarch64:
+    name: ${{ matrix.name }}-aarch64
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - {name: 'Python3.8', os: focal, tox: py38}
+          - {name: 'PyPy', os: focal, tox: pypy3}
+          - {name: 'Python3.6', os: bionic, tox: py36}
+          - {name: 'Python3.7', os: bionic, tox: py37}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Docker Buildx
+        id: Buildx
+        uses: crazy-max/ghaction-docker-buildx@v3.3.0
+        with:
+          buildx-version: latest
+          qemu-version: latest
+      - name: Use docker to install and emulate AArch64 tests
+        run: >
+          docker buildx build --platform linux/arm64
+          -t markupsafe_unittest --build-arg PYTHON=${{ matrix.tox }} --build-arg VERSION=${{ matrix.os }}
+          -f .github/workflows/Dockerfile_aarch64_test .


### PR DESCRIPTION
## What does this PR do?

This PR adds the ability to test and build Markupsafe for Arm64 platforms.  It uses docker buildx via github actions to emulate the arm64 platform as currently github does not support native arm64.

## What does this PR add?
- Modifies `.github/workflows/tests.yaml` and `.github/workflows/build.yaml` to do arm64 tests and builds
- Adds to `.github/workflows/` the support files for testing and building wheels on arm64: `Dockerfile_aarch64_build`, `Dockerfile_aarch64_test`, and `build-manylinux-wheels.sh`.