### PR TITLE
Add Python 3.9 support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.9'
       - run: pip install cibuildwheel
       - run: cibuildwheel
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,14 +16,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {name: Linux, python: '3.8', os: ubuntu-latest, tox: py38}
-          - {name: Windows, python: '3.8', os: windows-latest, tox: py38}
-          - {name: Mac, python: '3.8', os: macos-latest, tox: py38}
+          - {name: Linux, python: '3.9', os: ubuntu-latest, tox: py39}
+          - {name: Windows, python: '3.9', os: windows-latest, tox: py39}
+          - {name: Mac, python: '3.9', os: macos-latest, tox: py39}
+          - {name: '3.8', python: '3.8', os: ubuntu-latest, tox: py38}
           - {name: '3.7', python: '3.7', os: ubuntu-latest, tox: py37}
           - {name: '3.6', python: '3.6', os: ubuntu-latest, tox: py36}
           - {name: 'PyPy', python: pypy3, os: ubuntu-latest, tox: pypy3}
-          - {name: Style, python: '3.8', os: ubuntu-latest, tox: style}
-          - {name: Docs, python: '3.8', os: ubuntu-latest, tox: docs}
+          - {name: Style, python: '3.9', os: ubuntu-latest, tox: style}
+          - {name: Docs, python: '3.9', os: ubuntu-latest, tox: docs}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,37,36,py3}
+    py{39,38,37,36,py3}
     style
     docs
 skip_missing_interpreters = true


### PR DESCRIPTION
Greetings fellows!
Thanks for maintaining this project!

I'd like to add Python 3.9 support here, as [it was released a month ago](https://www.python.org/downloads/release/python-390/) and started being used here and there.

This PR:

- Adds Python 3.9 to GitHub actions and tox
- Replaces 3.8 with 3.9 for windows, mac, docs and linting builds


I am happy to elaborate if anything else needed here!

Best,
Rust