### PR TITLE
Build aarch64 wheels

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,13 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     env:
       CIBW_SKIP: 'cp27-* pp27-* cp35-*'
+      CIBW_ARCHS_LINUX: auto aarch64
     steps:
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: arm64
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
From v1.8.0, cibuildwheel allows for building non-native architectures with the CIBW_ARCHS_LINUX option.

See https://cibuildwheel.readthedocs.io/en/stable/options/#archs for more details.