### PR TITLE
don't build speedups on PyPy with cibuildwheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,9 +52,11 @@ def show_message(*lines):
     print("=" * 74)
 
 
-if os.environ.get("CIBUILDWHEEL", "0") == "1":
+supports_speedups = platform.python_implementation() not in {"PyPy", "Jython"}
+
+if os.environ.get("CIBUILDWHEEL", "0") == "1" and supports_speedups:
     run_setup(True)
-elif platform.python_implementation() not in {"PyPy", "Jython"}:
+elif supports_speedups:
     try:
         run_setup(True)
     except BuildFailed:


### PR DESCRIPTION
The C extension is twice as slow as the native code on PyPy. Maybe this can be re-evaluated later.

closes #176 