### PR TITLE
feat: use py limited ABI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     env:
-      CIBW_SKIP: 'cp27-* cp35-* pp*'
+      CIBW_BUILD: 'cp36-*'
       CIBW_ARCHS_LINUX: auto aarch64
     steps:
       - name: Set up QEMU
@@ -24,11 +24,11 @@ jobs:
         with:
           platforms: arm64
       - uses: actions/checkout@v2
+      - uses: joerick/cibuildwheel@v1.9.0
       - uses: actions/setup-python@v2
         with:
           python-version: '3.9'
-      - run: pip install cibuildwheel
-      - run: cibuildwheel
+      # Install and test on 3.9 here!
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse

--- a/setup.cfg
+++ b/setup.cfg
@@ -84,3 +84,6 @@ warn_unused_configs = true
 warn_unused_ignores = true
 warn_return_any = true
 warn_unreachable = true
+
+[bdist_wheel]
+py-limited-api = cp36

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,13 @@ from setuptools import Extension
 from setuptools import setup
 from setuptools.command.build_ext import build_ext
 
-ext_modules = [Extension("markupsafe._speedups", ["src/markupsafe/_speedups.c"])]
+ext_modules = [
+    Extension(
+        "markupsafe._speedups",
+        ["src/markupsafe/_speedups.c"],
+        py_limited_api=True,
+    )
+]
 
 
 class BuildFailed(Exception):


### PR DESCRIPTION
<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #175

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.


----


Quick base for a Limited API build; this creates both a correctly named wheel, with correctly named insides seen with `unzip -l`, when I run `pipx run --spec build pyproject-build`. I've reworked the wheel building just a bit to make it easier to at test with a later version of Python (probably you want to run tox but load the wheel each time, perhaps? Or just load on 3.9 and verify it passes PyTest. This part depends on the project specifics).

If you can clean up the setup.py, go ahead, don't want to get in the way of that. :)
