### PR TITLE
build py_limited_api abi3 wheel and MacOS universal2 wheel

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,21 +14,18 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-    env:
-      CIBW_SKIP: 'cp27-* cp35-* pp*'
-      CIBW_ARCHS_LINUX: auto aarch64
     steps:
+      - uses: actions/checkout@v2
       - name: Set up QEMU
         if: runner.os == 'Linux'
         uses: docker/setup-qemu-action@v1
         with:
           platforms: arm64
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.9'
-      - run: pip install cibuildwheel
-      - run: cibuildwheel
+      - uses: joerick/cibuildwheel@v1.9.0
+        env:
+          CIBW_BUILD: cp36-* cp39-macosx_universal2
+          CIBW_ARCHS_LINUX: auto aarch64
+          CIBW_ARCHS_MACOS: auto universal2
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,9 @@ python_requires = >= 3.6
 [options.packages.find]
 where = src
 
+[bdist_wheel]
+py-limited-api = cp36
+
 [tool:pytest]
 testpaths = tests
 filterwarnings =

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,11 @@ from setuptools import Extension
 from setuptools import setup
 from setuptools.command.build_ext import build_ext
 
-ext_modules = [Extension("markupsafe._speedups", ["src/markupsafe/_speedups.c"])]
+ext_modules = [
+    Extension(
+        "markupsafe._speedups", ["src/markupsafe/_speedups.c"], py_limited_api=True
+    )
+]
 
 
 class BuildFailed(Exception):


### PR DESCRIPTION
Use py_limited_api to build one wheel for 3.6+. Currently testing this.

Use cibuildwheel as a GitHub action. Don't need `setup-python` or `pip install`.

Build a MacOS universal2 wheel. From what I could tell from the cibuildwheel docs, this seems to be preferred over building the arm64 wheel.

closes #175 