### PR TITLE
remove abi3 limited api builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
           platforms: arm64
       - uses: joerick/cibuildwheel@v1.9.0
         env:
-          CIBW_BUILD: cp36-* cp39-macosx_universal2
+          CIBW_SKIP: 'cp27-* cp35-* pp*'
           CIBW_ARCHS_LINUX: auto aarch64
           CIBW_ARCHS_MACOS: auto universal2
       - uses: actions/upload-artifact@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,9 +34,6 @@ python_requires = >= 3.6
 [options.packages.find]
 where = src
 
-[bdist_wheel]
-py-limited-api = cp36
-
 [tool:pytest]
 testpaths = tests
 filterwarnings =

--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,7 @@ from setuptools import Extension
 from setuptools import setup
 from setuptools.command.build_ext import build_ext
 
-ext_modules = [
-    Extension(
-        "markupsafe._speedups", ["src/markupsafe/_speedups.c"], py_limited_api=True
-    )
-]
+ext_modules = [Extension("markupsafe._speedups", ["src/markupsafe/_speedups.c"])]
 
 
 class BuildFailed(Exception):


### PR DESCRIPTION
MarkupSafe uses the Python Unicode API, which is mostly unavailable with `Py_LIMITED_API`.  I don't have the expertise to rewrite the C to be compatible with the limited API, so I'll continue to build version wheels for now. While it would be nice to build fewer wheels with abi3, it's not particularly a problem for me to push a new CI config then upload the new wheels when a new Python version is available.

closes #175 