### PR TITLE
call string.Formatter.__init__

### DIFF
--- a/src/markupsafe/__init__.py
+++ b/src/markupsafe/__init__.py
@@ -211,6 +211,8 @@ class Markup(str):
 
 
 class EscapeFormatter(string.Formatter):
+    __slots__ = ("escape",)
+
     def __init__(self, escape: t.Callable[[t.Any], Markup]) -> None:
         self.escape = escape
         super().__init__()
@@ -249,6 +251,8 @@ def _escape_argspec(
 
 class _MarkupEscapeHelper:
     """Helper for :meth:`Markup.__mod__`."""
+
+    __slots__ = ("obj", "escape")
 
     def __init__(self, obj: t.Any, escape: t.Callable[[t.Any], Markup]) -> None:
         self.obj = obj

--- a/src/markupsafe/__init__.py
+++ b/src/markupsafe/__init__.py
@@ -213,6 +213,7 @@ class Markup(str):
 class EscapeFormatter(string.Formatter):
     def __init__(self, escape: t.Callable[[t.Any], Markup]) -> None:
         self.escape = escape
+        super().__init__()
 
     def format_field(self, value: t.Any, format_spec: str) -> str:
         if hasattr(value, "__html_format__"):


### PR DESCRIPTION
Noticed this while adding types to Jinja. `EscapeFormatter` should call `super().__init__()`. It doesn't affect anything, but is more correct for subclassing hierarchies.

Also, `EscapeFormatter`, and `_MarkupEscapeHelper` can use slots to avoid some overhead. This is more useful for the the helper class, which may be created many times when doing `Markup % args`. `Markup` already uses slots.