### PR TITLE
cibuildwheel skips based on python_requires

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,9 @@ on:
       - '*.x'
     tags:
       - '*'
+  pull_request:
+    branches:
+      - '*'
 jobs:
   wheels:
     name: ${{ matrix.os }}
@@ -23,7 +26,7 @@ jobs:
           platforms: arm64
       - uses: joerick/cibuildwheel@v1.9.0
         env:
-          CIBW_SKIP: 'cp27-* cp35-* pp*'
+          CIBW_SKIP: 'pp*'
           CIBW_ARCHS_LINUX: auto aarch64
           CIBW_ARCHS_MACOS: auto universal2
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: docker/setup-qemu-action@v1
         with:
           platforms: arm64
-      - uses: joerick/cibuildwheel@v1.9.0
+      - uses: joerick/cibuildwheel@v1.11.0
         env:
           CIBW_SKIP: 'pp*'
           CIBW_ARCHS_LINUX: auto aarch64


### PR DESCRIPTION
- Update cibuildwheel to 1.11.0.
- cibuildwheel 1.9.0 automatically skips versions based on `python_requires`.