### PR TITLE
raise error upon missing placeholder

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,9 @@ Version 2.1.0
 
 Unreleased
 
+-   Raise error on missing single placeholder during string
+    interpolation. :issue:`225`
+
 
 Version 2.0.2
 -------------

--- a/src/markupsafe/__init__.py
+++ b/src/markupsafe/__init__.py
@@ -102,9 +102,14 @@ class Markup(str):
 
     def __mod__(self, arg: t.Any) -> "Markup":
         if isinstance(arg, tuple):
+            # a tuple of arguments, each wrapped
             arg = tuple(_MarkupEscapeHelper(x, self.escape) for x in arg)
-        else:
+        elif hasattr(type(arg), "__getitem__") and not isinstance(arg, str):
+            # a mapping of arguments, wrapped
             arg = _MarkupEscapeHelper(arg, self.escape)
+        else:
+            # a single argument, wrapped with the helper and a tuple
+            arg = (_MarkupEscapeHelper(arg, self.escape),)
 
         return self.__class__(super().__mod__(arg))
 

--- a/tests/test_markupsafe.py
+++ b/tests/test_markupsafe.py
@@ -45,6 +45,12 @@ def test_html_interop():
     assert result == "<strong><em>awesome</em></strong>"
 
 
+@pytest.mark.parametrize("args", ["foo", 42, ("foo", 42)])
+def test_missing_interpol(args):
+    with pytest.raises(TypeError):
+        Markup("<em></em>") % args
+
+
 def test_tuple_interpol():
     result = Markup("<em>%s:%s</em>") % ("<foo>", "<bar>")
     expect = Markup("<em>&lt;foo&gt;:&lt;bar&gt;</em>")


### PR DESCRIPTION
In the scenario of a missing single placeholder, the mod operator did
not fail as it does when having multiple placeholder
```py
>>> Markup("foo") % 42
Markup("foo")
>>> Markup("foo") % (42, 43)
TypeError: not all arguments converted during string formatting
>>> Markup("foo") % (42,)
TypeError: not all arguments converted during string formatting
```
This commits unifies the behaviour with the mod operator on native
strings and fails in the three above scenario

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #225

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
