### PR TITLE
update pip link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Install and update using `pip`_:
 
     pip install -U MarkupSafe
 
-.. _pip: https://pip.pypa.io/en/stable/quickstart/
+.. _pip: https://pip.pypa.io/en/stable/getting-started/
 
 
 Examples


### PR DESCRIPTION
Update link to pip documentation in README.rst from https://pip.pypa.io/en/stable/quickstart/ to https://pip.pypa.io/en/stable/getting-started/