### PR TITLE
avoid ambiguous regex in striptags

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+Version 2.1.1
+-------------
+
+Unreleased
+
+-   Avoid ambiguous regex matches in ``striptags``. :pr:`293`
+
+
 Version 2.1.0
 -------------
 

--- a/src/markupsafe/__init__.py
+++ b/src/markupsafe/__init__.py
@@ -11,9 +11,10 @@ if t.TYPE_CHECKING:
             pass
 
 
-__version__ = "2.1.0"
+__version__ = "2.1.1.dev0"
 
-_striptags_re = re.compile(r"(<!--.*?-->|<[^>]*>)")
+_strip_comments_re = re.compile(r"<!--.*?-->")
+_strip_tags_re = re.compile(r"<.*?>")
 
 
 def _simple_escaping_wrapper(name: str) -> t.Callable[..., "Markup"]:
@@ -158,8 +159,11 @@ class Markup(str):
         >>> Markup("Main &raquo;\t<em>About</em>").striptags()
         'Main » About'
         """
-        stripped = " ".join(_striptags_re.sub("", self).split())
-        return Markup(stripped).unescape()
+        # Use two regexes to avoid ambiguous matches.
+        value = _strip_comments_re.sub("", self)
+        value = _strip_tags_re.sub("", value)
+        value = " ".join(value.split())
+        return Markup(value).unescape()
 
     @classmethod
     def escape(cls, s: t.Any) -> "Markup":

--- a/tests/test_markupsafe.py
+++ b/tests/test_markupsafe.py
@@ -69,7 +69,15 @@ def test_dict_interpol():
 
 def test_escaping(escape):
     assert escape("\"<>&'") == "&#34;&lt;&gt;&amp;&#39;"
-    assert Markup("<em>Foo &amp; Bar</em>").striptags() == "Foo & Bar"
+    assert (
+        Markup(
+            "<!-- outer comment -->"
+            "<em>Foo &amp; Bar"
+            "<!-- inner comment about <em> -->"
+            "</em>"
+        ).striptags()
+        == "Foo & Bar"
+    )
 
 
 def test_unescape():


### PR DESCRIPTION
Split up regex used by `striptags` to handle comments before tags. This avoids ambiguous regex matches which could lead to backtracking.