### PR TITLE
Match newlines when stripping tags

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,9 @@ Version 2.1.2
 
 Unreleased
 
+-   Fix ``striptags`` not stripping tags containing newlines.
+    :issue:`310`
+
 
 Version 2.1.1
 -------------

--- a/src/markupsafe/__init__.py
+++ b/src/markupsafe/__init__.py
@@ -13,8 +13,8 @@ if t.TYPE_CHECKING:
 
 __version__ = "2.1.2.dev0"
 
-_strip_comments_re = re.compile(r"<!--.*?-->")
-_strip_tags_re = re.compile(r"<.*?>")
+_strip_comments_re = re.compile(r"<!--.*?-->", re.DOTALL)
+_strip_tags_re = re.compile(r"<.*?>", re.DOTALL)
 
 
 def _simple_escaping_wrapper(name: str) -> t.Callable[..., "Markup"]:

--- a/tests/test_markupsafe.py
+++ b/tests/test_markupsafe.py
@@ -75,6 +75,8 @@ def test_escaping(escape):
             "<em>Foo &amp; Bar"
             "<!-- inner comment about <em> -->"
             "</em>"
+            "<!-- comment\nwith\nnewlines\n-->"
+            "<meta content='tag\nwith\nnewlines'>"
         ).striptags()
         == "Foo & Bar"
     )


### PR DESCRIPTION
Fixes #310

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
