### PR TITLE
CI: Update to Python 3.11 stable

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: docker/setup-qemu-action@v2
         with:
           platforms: arm64
-      - uses: joerick/cibuildwheel@v2.10.2
+      - uses: joerick/cibuildwheel@v2
         env:
           CIBW_SKIP: 'pp*'
           CIBW_ARCHS_LINUX: auto aarch64

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,15 +24,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {name: Linux, python: '3.10', os: ubuntu-latest, tox: py310}
-          - {name: Windows, python: '3.10', os: windows-latest, tox: py310}
-          - {name: Mac, python: '3.10', os: macos-latest, tox: py310}
-          - {name: '3.11-dev', python: '3.11-dev', os: ubuntu-latest, tox: py311}
+          - {name: Linux, python: '3.11', os: ubuntu-latest, tox: py311}
+          - {name: Windows, python: '3.11', os: windows-latest, tox: py311}
+          - {name: Mac, python: '3.11', os: macos-latest, tox: py311}
+          - {name: '3.10', python: '3.10', os: ubuntu-latest, tox: py310}
           - {name: '3.9', python: '3.9', os: ubuntu-latest, tox: py39}
           - {name: '3.8', python: '3.8', os: ubuntu-latest, tox: py38}
           - {name: '3.7', python: '3.7', os: ubuntu-latest, tox: py37}
           - {name: 'PyPy', python: 'pypy-3.7', os: ubuntu-latest, tox: pypy37}
-          - {name: Typing, python: '3.10', os: ubuntu-latest, tox: typing}
+          - {name: Typing, python: '3.11', os: ubuntu-latest, tox: typing}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4


### PR DESCRIPTION
A bit of CI maintanance;
- Update to the latest cibuildwheel version (which builds Python 3.11 wheels by default)
- Switch the macOS, Windows and Typing builds over to Python 3.11. 3.11 is faster and provide better error messages, which helps on CI failures.

Since cibuildwheels builds Python 3.11 wheels by default, tagging a new release, letting the CI run and uploading those wheels could fix #327 and #328 simultaniously.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
