### PR TITLE
Test Python 3.11 on Linux, Windows and Mac, add 3.12-dev

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,15 +24,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {name: Linux, python: '3.10', os: ubuntu-latest, tox: py310}
-          - {name: Windows, python: '3.10', os: windows-latest, tox: py310}
-          - {name: Mac, python: '3.10', os: macos-latest, tox: py310}
-          - {name: '3.11-dev', python: '3.11-dev', os: ubuntu-latest, tox: py311}
+          - {name: Linux, python: '3.11', os: ubuntu-latest, tox: py311}
+          - {name: Windows, python: '3.11', os: windows-latest, tox: py311}
+          - {name: Mac, python: '3.11', os: macos-latest, tox: py311}
+          - {name: '3.12-dev', python: '3.12-dev', os: ubuntu-latest, tox: py312}
+          - {name: '3.10', python: '3.10', os: ubuntu-latest, tox: py310}
           - {name: '3.9', python: '3.9', os: ubuntu-latest, tox: py39}
           - {name: '3.8', python: '3.8', os: ubuntu-latest, tox: py38}
           - {name: '3.7', python: '3.7', os: ubuntu-latest, tox: py37}
           - {name: 'PyPy', python: 'pypy-3.7', os: ubuntu-latest, tox: pypy37}
-          - {name: Typing, python: '3.10', os: ubuntu-latest, tox: typing}
+          - {name: Typing, python: '3.11', os: ubuntu-latest, tox: typing}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,27 +3,27 @@ ci:
   autoupdate_schedule: monthly
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.34.0
+    rev: v3.2.2
     hooks:
       - id: pyupgrade
         args: ["--py37-plus"]
   - repo: https://github.com/asottile/reorder_python_imports
-    rev: v3.1.0
+    rev: v3.9.0
     hooks:
       - id: reorder-python-imports
         args: ["--application-directories", "src"]
         additional_dependencies: ["setuptools>60.9"]
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.10.0
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
       - id: flake8
         additional_dependencies: [flake8-bugbear]
   - repo: https://github.com/peterdemin/pip-compile-multi
-    rev: v2.4.5
+    rev: v2.5.0
     hooks:
       - id: pip-compile-multi-verify
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Unreleased
 
 -   Fix ``striptags`` not stripping tags containing newlines.
     :issue:`310`
+-   Add support for Python 3.11. :issue:`327`
 
 
 Version 2.1.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,51 +8,51 @@
 -r docs.txt
 -r tests.txt
 -r typing.txt
+build==0.9.0
+    # via pip-tools
 cfgv==3.3.1
     # via pre-commit
 click==8.1.3
     # via
     #   pip-compile-multi
     #   pip-tools
-distlib==0.3.4
+distlib==0.3.6
     # via virtualenv
-filelock==3.7.1
+filelock==3.8.0
     # via
     #   tox
     #   virtualenv
-identify==2.5.1
+identify==2.5.9
     # via pre-commit
-nodeenv==1.6.0
+nodeenv==1.7.0
     # via pre-commit
-pep517==0.12.0
-    # via pip-tools
-pip-compile-multi==2.4.5
+pep517==0.13.0
+    # via build
+pip-compile-multi==2.5.0
     # via -r requirements/dev.in
-pip-tools==6.6.2
+pip-tools==6.10.0
     # via pip-compile-multi
-platformdirs==2.5.2
+platformdirs==2.5.4
     # via virtualenv
-pre-commit==2.19.0
+pre-commit==2.20.0
     # via -r requirements/dev.in
+py==1.11.0
+    # via tox
 pyyaml==6.0
     # via pre-commit
 six==1.16.0
-    # via
-    #   tox
-    #   virtualenv
+    # via tox
 toml==0.10.2
-    # via
-    #   pre-commit
-    #   tox
+    # via pre-commit
 toposort==1.7
     # via pip-compile-multi
-tox==3.25.0
+tox==3.27.1
     # via -r requirements/dev.in
-virtualenv==20.14.1
+virtualenv==20.16.7
     # via
     #   pre-commit
     #   tox
-wheel==0.37.1
+wheel==0.38.4
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -7,17 +7,17 @@
 #
 alabaster==0.7.12
     # via sphinx
-babel==2.10.1
+babel==2.11.0
     # via sphinx
-certifi==2022.5.18.1
+certifi==2022.9.24
     # via requests
-charset-normalizer==2.0.12
+charset-normalizer==2.1.1
     # via requests
-docutils==0.18.1
+docutils==0.19
     # via sphinx
-idna==3.3
+idna==3.4
     # via requests
-imagesize==1.3.0
+imagesize==1.4.1
     # via sphinx
 jinja2==3.1.2
     # via sphinx
@@ -29,17 +29,17 @@ packaging==21.3
     #   sphinx
 pallets-sphinx-themes==2.0.2
     # via -r requirements/docs.in
-pygments==2.12.0
+pygments==2.13.0
     # via sphinx
 pyparsing==3.0.9
     # via packaging
-pytz==2022.1
+pytz==2022.6
     # via babel
-requests==2.28.0
+requests==2.28.1
     # via sphinx
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==5.0.1
+sphinx==5.3.0
     # via
     #   -r requirements/docs.in
     #   pallets-sphinx-themes
@@ -61,5 +61,5 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-urllib3==1.26.9
+urllib3==1.26.12
     # via requests

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -5,7 +5,7 @@
 #
 #    pip-compile-multi
 #
-attrs==21.4.0
+attrs==22.1.0
     # via pytest
 iniconfig==1.1.1
     # via pytest
@@ -13,11 +13,7 @@ packaging==21.3
     # via pytest
 pluggy==1.0.0
     # via pytest
-py==1.11.0
-    # via pytest
 pyparsing==3.0.9
     # via packaging
-pytest==7.1.2
+pytest==7.2.0
     # via -r requirements/tests.in
-tomli==2.0.1
-    # via pytest

--- a/requirements/typing.txt
+++ b/requirements/typing.txt
@@ -5,11 +5,9 @@
 #
 #    pip-compile-multi
 #
-mypy==0.961
+mypy==0.991
     # via -r requirements/typing.in
 mypy-extensions==0.4.3
     # via mypy
-tomli==2.0.1
-    # via mypy
-typing-extensions==4.2.0
+typing-extensions==4.4.0
     # via mypy

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py3{11,10,9,8,7},pypy3{8,7}
+    py3{12,11,10,9,8,7},pypy3{8,7}
     style
     typing
     docs


### PR DESCRIPTION
Update tests for 3.11 and 3.12-dev. Update dependencies since flake8 was not compatible with Python 3.12.

Only after making the changes, I noticed there was already #329. Since there has been no release since, I anyway create this pull request in hopes it'll help get the release with 3.11 support sooner rather than later.

- fixes #327

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [X] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [X] Run `pre-commit` hooks and fix any issues.
- [X] Run `pytest` and `tox`, no tests failed.
