### PR TITLE
implement missing `str` methods

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,8 +3,9 @@ Version 2.1.3
 
 Unreleased
 
+-   Implement ``format_map``, ``casefold``, ``removeprefix``, and ``removesuffix``
+    methods. :issue:`370`
 -   Fix static typing for basic ``str`` methods on ``Markup``. :issue:`358`
--   Implement ``format_map`` method. :issue:`370`
 
 
 Version 2.1.2

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Version 2.1.3
 Unreleased
 
 -   Fix static typing for basic ``str`` methods on ``Markup``. :issue:`358`
+-   Implement ``format_map`` method. :issue:`370`
 
 
 Version 2.1.2

--- a/src/markupsafe/__init__.py
+++ b/src/markupsafe/__init__.py
@@ -208,6 +208,10 @@ class Markup(str):
         formatter = EscapeFormatter(self.escape)
         return self.__class__(formatter.vformat(self, args, kwargs))
 
+    def format_map(self, map: t.Mapping[str, t.Any]) -> str:  # type: ignore[override]
+        formatter = EscapeFormatter(self.escape)
+        return self.__class__(formatter.vformat(self, (), map))
+
     def __html_format__(self, format_spec: str) -> "Markup":
         if format_spec:
             raise ValueError("Unsupported format specification for Markup.")

--- a/src/markupsafe/__init__.py
+++ b/src/markupsafe/__init__.py
@@ -1,6 +1,7 @@
 import functools
 import re
 import string
+import sys
 import typing as t
 
 if t.TYPE_CHECKING:
@@ -193,6 +194,11 @@ class Markup(str):
     expandtabs = _simple_escaping_wrapper(str.expandtabs)
     swapcase = _simple_escaping_wrapper(str.swapcase)
     zfill = _simple_escaping_wrapper(str.zfill)
+    casefold = _simple_escaping_wrapper(str.casefold)
+
+    if sys.version_info >= (3, 9):
+        removeprefix = _simple_escaping_wrapper(str.removeprefix)
+        removesuffix = _simple_escaping_wrapper(str.removesuffix)
 
     def partition(self, sep: str) -> t.Tuple["Markup", "Markup", "Markup"]:
         l, s, r = super().partition(self.escape(sep))

--- a/tests/test_markupsafe.py
+++ b/tests/test_markupsafe.py
@@ -108,6 +108,11 @@ def test_format():
     assert result == "<bar/>"
 
 
+def test_format_map():
+    result = Markup("<em>{value}</em>").format_map({"value": "<value>"})
+    assert result == "<em>&lt;value&gt;</em>"
+
+
 def test_formatting_empty():
     formatted = Markup("{}").format(0)
     assert formatted == Markup("0")


### PR DESCRIPTION
`format_map` was missing, meaning the format arguments would not be escaped when using it. `casefold`, `removeprefix`, and `removesuffix` were missing, meaning they'd return `str` instead of `Markup`. The `remove...` methods are only in Python >= 3.9.

fixes #370