### PR TITLE
deprecate `__version__` attribute

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-Version 2.2.0
+Version 3.0.0
 -------------
 
 Unreleased

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Unreleased
     argument. These methods are conceptually linked to search methods such as
     ``in``, ``find``, and ``index``, which already do not escape their argument.
     :issue:`401`
+-   The ``__version__`` attribute is deprecated. Use feature detection, or
+    ``importlib.metadata.version("markupsafe")``, instead. :pr:`402`
 
 
 Version 2.1.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "MarkupSafe"
-version = "2.2.0.dev"
+version = "3.0.0.dev"
 description = "Safely add untrusted strings to HTML/XML markup."
 readme = "README.rst"
 license = {text = "BSD-3-Clause"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [project]
 name = "MarkupSafe"
+version = "2.2.0.dev"
 description = "Safely add untrusted strings to HTML/XML markup."
 readme = "README.rst"
 license = {text = "BSD-3-Clause"}
@@ -15,7 +16,6 @@ classifiers = [
     "Topic :: Text Processing :: Markup :: HTML",
 ]
 requires-python = ">=3.8"
-dynamic = ["version"]
 
 [project.urls]
 Donate = "https://palletsprojects.com/donate"

--- a/src/markupsafe/__init__.py
+++ b/src/markupsafe/__init__.py
@@ -18,8 +18,6 @@ if t.TYPE_CHECKING:
             ...
 
 
-__version__ = "2.2.0.dev"
-
 _strip_comments_re = re.compile(r"<!--.*?-->", re.DOTALL)
 _strip_tags_re = re.compile(r"<.*?>", re.DOTALL)
 
@@ -315,3 +313,19 @@ except ImportError:
     from ._native import escape as escape
     from ._native import escape_silent as escape_silent  # noqa: F401
     from ._native import soft_str as soft_str  # noqa: F401
+
+
+def __getattr__(name: str) -> t.Any:
+    if name == "__version__":
+        import importlib.metadata
+        import warnings
+
+        warnings.warn(
+            "The '__version__' attribute is deprecated and will be removed in"
+            " MarkupSafe 3.1. Use feature detection, or"
+            ' `importlib.metadata.version("markupsafe")`, instead.',
+            stacklevel=2,
+        )
+        return importlib.metadata.version("flask-classful")
+
+    raise AttributeError(name)


### PR DESCRIPTION
The `__version__` attribute is an old pattern from early in Python packaging. Setuptools eventually made it easier to use the pattern by allowing reading the value from the attribute at build time, and some other build backends have done the same.

However, there's no reason to expose this directly in code anymore. It's usually easier to use feature detection (`hasattr`, `try/except`) instead. `importlib.metadata.version("markupsafe")` can be used to get the version at runtime in a standard way, if it's really needed.

---

Also, given some of the changes going into the next version, 3.0 feels more appropriate than 2.2.