### PR TITLE
Fix for spurious whitespace in striptags output

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Version 2.1.5
 
 Unreleased
 
+-   Fix ``striptags`` not collapsing spaces. :issue:`417`
+
 
 Version 2.1.4
 -------------

--- a/src/markupsafe/__init__.py
+++ b/src/markupsafe/__init__.py
@@ -158,8 +158,7 @@ class Markup(str):
         >>> Markup("Main &raquo;\t<em>About</em>").striptags()
         'Main » About'
         """
-        # collapse spaces
-        value = " ".join(self.split())
+        value = str(self)
 
         # Look for comments then tags separately. Otherwise, a comment that
         # contains a tag would end early, leaving some of the comment behind.
@@ -193,6 +192,8 @@ class Markup(str):
 
             value = f"{value[:start]}{value[end + 1:]}"
 
+        # collapse spaces
+        value = " ".join(value.split())
         return self.__class__(value).unescape()
 
     @classmethod

--- a/tests/test_markupsafe.py
+++ b/tests/test_markupsafe.py
@@ -73,7 +73,7 @@ def test_escaping(escape):
         Markup(
             "<!-- outer comment -->"
             "<em>Foo &amp; Bar"
-            "<!-- inner comment about <em> -->"
+            " <!-- inner comment about <em> -->\n "
             "</em>"
             "<!-- comment\nwith\nnewlines\n-->"
             "<meta content='tag\nwith\nnewlines'>"


### PR DESCRIPTION
This PR restores order of operations in Markup.striptags.

Prior to 2.1.4, the order of operations in striptags was:
1. strip comments
2. strip tags
3. coalesce whitespace

In 2.1.4 the order changed to:
1. coalesce whitespace
2. strip comments
3. strip tags

As a result extra spaces were introduced in the output in cases where whitespace was separated from more whitespace by a tag or comment.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #417

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [n/a] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [n/a] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
