### PR TITLE
Skip costly attribute check for unicode strings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ Unreleased
     :issue:`401`
 -   The ``__version__`` attribute is deprecated. Use feature detection, or
     ``importlib.metadata.version("markupsafe")``, instead. :pr:`402`
+-   Improve speedups for plain strings by 30-40%. :pr:`434`
 
 
 Version 2.1.5


### PR DESCRIPTION
This PR reduces the overall call time to `escape()` by about 40% when the input is a string by not calling `PyObject_GetAttr()` _unless_ it isn't a unicode object.

`PyObject_GetAttr` is one of the most expensive calls in the C-API, compared with `PyUnicode_CheckExact` which is an interned pointer comparison (very fast).

Before: 

<img width="874" alt="screenshot 2024-04-19 at 14 10 56" src="https://github.com/pallets/markupsafe/assets/1532417/10f1f810-606e-46c0-a741-2ec221c7ceb1">

After:

<img width="905" alt="screenshot 2024-04-19 at 14 06 29" src="https://github.com/pallets/markupsafe/assets/1532417/433ebe12-3594-4f99-a6da-5c262b6829ed">
