### PR TITLE
Fixed the ability to import markupsafe with runtime type checker

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,8 @@ Unreleased
     ``importlib.metadata.version("markupsafe")``, instead. :pr:`402`
 -   Speed up escaping plain strings by 40%. :pr:`434`
 -   Simplify speedups implementation. :pr:`437`
+-   Add ``typing_extensions>=4.0.0`` as a dependency to satisfy the requirements
+    of runtime type checkers (eg ``beartype``).
 
 
 Version 2.1.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 requires-python = ">=3.8"
+dependencies = ["typing_extensions>=4.0.0"]
 
 [project.urls]
 Donate = "https://palletsprojects.com/donate"

--- a/src/markupsafe/__init__.py
+++ b/src/markupsafe/__init__.py
@@ -5,19 +5,22 @@ import string
 import sys
 import typing as t
 
+import typing_extensions as te
+
 try:
     from ._speedups import _escape_inner
 except ImportError:
     from ._native import _escape_inner
 
-if t.TYPE_CHECKING:
-    import typing_extensions as te
 
-    class HasHTML(te.Protocol):
-        def __html__(self, /) -> str: ...
+@te.runtime_checkable
+class HasHTML(te.Protocol):
+    def __html__(self, /) -> str: ...
 
-    class TPEscape(te.Protocol):
-        def __call__(self, s: t.Any, /) -> Markup: ...
+
+@te.runtime_checkable
+class TPEscape(te.Protocol):
+    def __call__(self, s: t.Any, /) -> Markup: ...
 
 
 def escape(s: t.Any, /) -> Markup:


### PR DESCRIPTION
Hello, I came here from https://github.com/beartype/beartype/issues/404 and I think I need to explain a little the reason for my appearance here.

I want to use full type checking at runtime when running tests.
It works as follows - import hooks are installed and each imported module will be checked for type safety at the moment when Python goes line by line through the new files.

Which leads to a certain peculiarity: information about types (type hints) is required not only in conjunction with TYPE_CHECKING, but also at runtime, which is why I needed to create this pull request in order to correct types at runtime.