### PR TITLE
Build Python 3.13 wheels

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -59,6 +59,7 @@ jobs:
           CIBW_ARCHS_LINUX: auto aarch64
           CIBW_ARCHS_MACOS: auto universal2
           CIBW_BUILD_FRONTEND: build
+          CIBW_FREE_THREADED_SUPPORT: 1
       - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
         with:
           name: build-wheels-${{ matrix.os }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -51,7 +51,7 @@ jobs:
         uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
         with:
           platforms: arm64
-      - uses: pypa/cibuildwheel@bd033a44476646b606efccdd5eed92d5ea1d77ad # v2.20.0
+      - uses: pypa/cibuildwheel@d4a2945fcc8d13f20a1b99d461b8e844d5fc6e23 # v2.21.1
         env:
           # For workflow_dispatch, only build the new Python version.
           CIBW_BUILD: ${{ inputs.python && format('{0}-*', inputs.python) || null }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,6 +22,7 @@ jobs:
       matrix:
         include:
           - {python: '3.13'}
+          - {name: 'Free-threaded', python: '3.13', free-threaded: true}
           - {python: '3.12'}
           - {name: Windows, python: '3.12', os: windows-latest}
           - {name: Mac, python: '3.12', os: macos-latest}
@@ -33,13 +34,21 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
+        if: ${{ !matrix.free-threaded }}
         with:
           python-version: ${{ matrix.python }}
           allow-prereleases: true
           cache: pip
           cache-dependency-path: requirements*/*.txt
+      - uses: deadsnakes/action@e640ac8743173a67cca4d7d77cd837e514bf98e8 # v3.2.0
+        if: ${{ matrix.free-threaded }}
+        with:
+          python-version: ${{ matrix.python }}
+          nogil: true
       - run: pip install tox
-      - run: tox run -e ${{ matrix.tox || format('py{0}', matrix.python) }}
+      - env:
+          PYTHON_GIL: ${{ matrix.free-threaded && '0' || '1' }}
+        run: tox run -e ${{ matrix.tox || format('py{0}', matrix.python) }}
   typing:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,7 @@ Unreleased
     ``importlib.metadata.version("markupsafe")``, instead. :pr:`402`
 -   Speed up escaping plain strings by 40%. :pr:`434`
 -   Simplify speedups implementation. :pr:`437`
+-   Publish wheels for Python 3.13. :pr:`461`
 
 
 Version 2.1.5

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Version 3.0.0
 
 Unreleased
 
+-   Support Python 3.13 and its experimental free-threaded build. :pr:`461`
 -   Drop support for Python 3.7 and 3.8.
 -   Use modern packaging metadata with ``pyproject.toml`` instead of ``setup.cfg``.
     :pr:`348`
@@ -20,7 +21,6 @@ Unreleased
     ``importlib.metadata.version("markupsafe")``, instead. :pr:`402`
 -   Speed up escaping plain strings by 40%. :pr:`434`
 -   Simplify speedups implementation. :pr:`437`
--   Publish wheels for Python 3.13. :pr:`461`
 
 
 Version 2.1.5

--- a/src/markupsafe/_speedups.c
+++ b/src/markupsafe/_speedups.c
@@ -191,11 +191,14 @@ PyMODINIT_FUNC
 PyInit__speedups(void)
 {
 	PyObject *m = PyModule_Create(&module_definition);
+
 	if (m == NULL) {
 		return NULL;
 	}
-#ifdef Py_GIL_DISABLED
+
+	#ifdef Py_GIL_DISABLED
 	PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
-#endif
+	#endif
+
 	return m;
 }

--- a/src/markupsafe/_speedups.c
+++ b/src/markupsafe/_speedups.c
@@ -190,5 +190,12 @@ static struct PyModuleDef module_definition = {
 PyMODINIT_FUNC
 PyInit__speedups(void)
 {
-	return PyModule_Create(&module_definition);
+	PyObject *m = PyModule_Create(&module_definition);
+	if (m == NULL) {
+		return NULL;
+	}
+#ifdef Py_GIL_DISABLED
+	PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+#endif
+	return m;
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,9 +17,10 @@ except ImportError:
 
 def pytest_report_header() -> list[str]:
     """Return a list of strings to be displayed in the header of the report."""
-    if sys.version_info < (3, 13):
-        return []
-    return [f"Free-threaded: {not sys._is_gil_enabled()}"]
+    if sys.version_info >= (3, 13):
+        return [f"Free-threaded: {not sys._is_gil_enabled()}"]
+
+    return []
 
 
 @pytest.fixture(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sysconfig
 import typing as t
 from types import ModuleType
 
@@ -12,6 +13,11 @@ try:
     from markupsafe import _speedups
 except ImportError:
     _speedups = None  # type: ignore
+
+
+def pytest_report_header() -> list[str]:
+    """Return a list of strings to be displayed in the header of the report."""
+    return [f"Free-threaded: {bool(sysconfig.get_config_var('Py_GIL_DISABLED'))}"]
 
 
 @pytest.fixture(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import sysconfig
+import sys
 import typing as t
 from types import ModuleType
 
@@ -17,7 +17,9 @@ except ImportError:
 
 def pytest_report_header() -> list[str]:
     """Return a list of strings to be displayed in the header of the report."""
-    return [f"Free-threaded: {bool(sysconfig.get_config_var('Py_GIL_DISABLED'))}"]
+    if sys.version_info < (3, 13):
+        return []
+    return [f"Free-threaded: {not sys._is_gil_enabled()}"]
 
 
 @pytest.fixture(

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ skip_missing_interpreters = true
 
 [testenv]
 package = wheel
+pass_env = PYTHON_GIL
 constrain_package_deps = true
 use_frozen_constraints = true
 deps = -r requirements/tests.txt


### PR DESCRIPTION
Python 3.13 RC1 was released recently[^1]:

<blockquote>

We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.13 compatibilities during this phase, and where necessary publish Python 3.13 wheels on PyPI to be ready for the final release of 3.13.0. Any binary wheels built against Python 3.13.0rc1 will work with future versions of Python 3.13. As always, report any issues to [the Python bug tracker ](https://github.com/python/cpython/issues).

</blockquote>

It'd be really nice to have wheels to start testing applications that use MarkupSafe before the eventual final release.

Thanks!

~PS: This PR is only for GIL-enabled 3.13 wheels and not free-threaded ones[^2], which will certainly involve a higher level of effort.~

[^1]: https://discuss.python.org/t/python-3-13-0-release-candidate-1-released/59703
[^2]: https://docs.python.org/3.13/whatsnew/3.13.html#free-threaded-cpython

Related: https://github.com/pallets/markupsafe/issues/460

<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
