### PR TITLE
Add free-threading support

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -59,6 +59,8 @@ jobs:
           CIBW_ARCHS_LINUX: auto aarch64
           CIBW_ARCHS_MACOS: auto universal2
           CIBW_BUILD_FRONTEND: build
+          CIBW_PRERELEASE_PYTHONS: true
+          CIBW_FREE_THREADED_SUPPORT: true
       - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
         with:
           name: build-wheels-${{ matrix.os }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -59,6 +59,7 @@ jobs:
           C:\Python313\python3.13t.exe -c "import sys; print(f'{sys._is_gil_enabled()=}')"
           echo "C:\Python313\Scripts" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           echo "C:\Python313" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "CPPFLAGS=-DPy_GIL_DISABLED=1" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - run: pip install tox
       - run: tox run -e ${{ matrix.tox || format('py{0}', matrix.python) }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -52,7 +52,7 @@ jobs:
       - if: ${{ matrix.nogil && matrix.os == 'windows-latest' }}
         shell: pwsh
         run: |
-          $pythonInstallerUrl = "https://www.python.org/ftp/python/3.13.0/python-3.13.0rc1-amd64.exe"
+          $pythonInstallerUrl = "https://www.python.org/ftp/python/3.13.0/python-3.13.0rc2-amd64.exe"
           Invoke-WebRequest $pythonInstallerUrl -OutFile setup-python.exe
           Start-Process "setup-python.exe" -argumentlist "/quiet PrependPath=1 TargetDir=C:\Python313 Include_freethreaded=1" -wait
           C:\Python313\python3.13t.exe -m pip install -U pip

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,6 +21,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - {name: '3.13 free-threading', nogil: true, tox: py313}
+          - {name: Windows free-threading, nogil: true, os: windows-latest, tox: py313}
           - {python: '3.13'}
           - {python: '3.12'}
           - {name: Windows, python: '3.12', os: windows-latest}
@@ -33,13 +35,34 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
+        if: ${{ ! matrix.nogil }}
         with:
           python-version: ${{ matrix.python }}
           allow-prereleases: true
           cache: pip
           cache-dependency-path: requirements*/*.txt
+
+      # Free-threading versions of python
+      # https://py-free-threading.github.io/ci/
+      - if: ${{ matrix.nogil && ! matrix.os }}
+        uses: deadsnakes/action@6c8b9b82fe0b4344f4b98f2775fcc395df45e494 # v3.1.0
+        with:
+          python-version: 3.13-dev
+          nogil: true
+      - if: ${{ matrix.nogil && matrix.os == 'windows-latest' }}
+        shell: pwsh
+        run: |
+          $pythonInstallerUrl = "https://www.python.org/ftp/python/3.13.0/python-3.13.0rc1-amd64.exe"
+          Invoke-WebRequest $pythonInstallerUrl -OutFile setup-python.exe
+          Start-Process "setup-python.exe" -argumentlist "/quiet PrependPath=1 TargetDir=C:\Python313 Include_freethreaded=1" -wait
+          C:\Python313\python3.13t.exe -m pip install -U pip
+          C:\Python313\python3.13t.exe -c "import sys; print(f'{sys._is_gil_enabled()=}')"
+          echo "C:\Python313\Scripts" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "C:\Python313" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
       - run: pip install tox
       - run: tox run -e ${{ matrix.tox || format('py{0}', matrix.python) }}
+                 --discover C:\Python313\python3.13t.exe
   typing:
     runs-on: ubuntu-latest
     steps:

--- a/src/markupsafe/_speedups.c
+++ b/src/markupsafe/_speedups.c
@@ -190,5 +190,12 @@ static struct PyModuleDef module_definition = {
 PyMODINIT_FUNC
 PyInit__speedups(void)
 {
-	return PyModule_Create(&module_definition);
+	PyObject *m = PyModule_Create(&module_definition);
+    if (m == NULL) {
+        return NULL;
+    }
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+#endif
+    return m;
 }

--- a/src/markupsafe/_speedups.c
+++ b/src/markupsafe/_speedups.c
@@ -191,11 +191,11 @@ PyMODINIT_FUNC
 PyInit__speedups(void)
 {
 	PyObject *m = PyModule_Create(&module_definition);
-    if (m == NULL) {
-        return NULL;
-    }
+	if (m == NULL) {
+		return NULL;
+	}
 #ifdef Py_GIL_DISABLED
-    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+	PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
 #endif
-    return m;
+	return m;
 }

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,8 @@ package = wheel
 constrain_package_deps = true
 use_frozen_constraints = true
 deps = -r requirements/tests.txt
+commands_pre =
+    -python -c 'import sys; sys.version_info >= (3, 13) and print(f"{sys._is_gil_enabled()=}")'
 commands = pytest -v --tb=short --basetemp={envtmpdir} {posargs}
 
 [testenv:style]

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist =
     typing
     docs
 skip_missing_interpreters = true
+requires = virtualenv>=20.26.3
 
 [testenv]
 package = wheel


### PR DESCRIPTION

This is an attempt to address  #460.  Mostly, I followed the instructions that @AA-Turner  linked to there.

I looked over _speedups.c.  My non-expert eye did not see anything that didn't look nogil-safe, so I just added the `Py_MOD_GIL_NOT_USED` declaration to the extension module.

The matrix in the tests.yaml workflow has been expanded to included free-threading versions of python3.13 under Linux and Windows.
The Linux tests work.
The Windows tests do not, for reasons that I do not understand.

I played with enabling free-threading cibuildwheel builds in a separate branch, and that seems to [just work](https://github.com/dairiki/markupsafe/actions/runs/10529492559). (Though I have not tested any of the resulting wheels to verify that they are usable.)

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.

fixes #<issue number>
-->

Fixes #460 
<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
