### PR TITLE
fix exact str check

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Version 3.0.1
 Unreleased
 
 -   Address compiler warnings that became errors in GCC 14. :issue:`466`
+-   Fix compatibility with proxy objects. :issue:`467`
 
 
 Version 3.0.0

--- a/src/markupsafe/__init__.py
+++ b/src/markupsafe/__init__.py
@@ -34,7 +34,9 @@ def escape(s: t.Any, /) -> Markup:
     """
     # If the object is already a plain string, skip __html__ check and string
     # conversion. This is the most common use case.
-    if s.__class__ is str:
+    # Use type(s) instead of s.__class__ because a proxy object may be reporting
+    # the __class__ of the proxied value.
+    if type(s) is str:
         return Markup(_escape_inner(s))
 
     if hasattr(s, "__html__"):


### PR DESCRIPTION
`escape` checked if `o.__class__ is str` to skip a cast/copy `str(o)`. However, proxy types that forward attribute access on to the proxied value would report `o.__class__` as `str`, even though they were still the proxy class. This caused the C speedups to fail since they expected to be working with str data at that point. Use `type(o) is str` instead, which can't be affected by proxies.

fixes #467
