### PR TITLE
relax speedups str check

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+Version 3.1.0
+-------------
+
+Unreleased
+
+
 Version 3.0.1
 -------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Version 3.1.0
 
 Unreleased
 
+-   Fix compatibility when ``__str__`` returns a ``str`` subclass. :issue:`472`
+
 
 Version 3.0.1
 -------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "MarkupSafe"
-version = "3.0.1"
+version = "3.1.0.dev"
 description = "Safely add untrusted strings to HTML/XML markup."
 readme = "README.md"
 license = { file = "LICENSE.txt" }

--- a/src/markupsafe/_speedups.c
+++ b/src/markupsafe/_speedups.c
@@ -151,7 +151,7 @@ escape_unicode_kind4(PyUnicodeObject *in)
 static PyObject*
 escape_unicode(PyObject *self, PyObject *s)
 {
-	if (!PyUnicode_CheckExact(s))
+	if (!PyUnicode_Check(s))
 		return NULL;
 
     // This check is no longer needed in Python 3.12.


### PR DESCRIPTION
`__str__` should return a `str`, but could return a subclass of `str` instead. Relax the C check from `PyUnicode_CheckExact` (exact type) to `PyUnicode_Check` (subclass). This will still fail if `__str__` returns a non-string, but at that point I'm calling it a bug in the code that does that.

fixes #472 

Also added a test for #467.