### PR TITLE
build requires at least setuptools 70.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Version 3.0.2
 Unreleased
 
 -   Fix compatibility when ``__str__`` returns a ``str`` subclass. :issue:`472`
+-   Build requires setuptools >= 70.1. :issue:`475`
 
 
 Version 3.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ Source = "https://github.com/pallets/markupsafe/"
 Chat = "https://discord.gg/pallets"
 
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=70.1"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Setuptools 70.1 builds wheels directly instead of needing the wheel package.

fixes #475 