### PR TITLE
fix(pyproject): set project.license to the right value

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,3 +11,4 @@ python:
 sphinx:
   builder: dirhtml
   fail_on_warning: true
+  configuration: docs/conf.py

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Version 3.1.0
 Unreleased
 
 -   fix(pyproject): set project.license to the right value. :issue:`488`
+-   fix(readthedocs): add missing sphinx.configuration key to .readthedocs.yml :issue:`490`
 
 Version 3.0.2
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Version 3.1.0
 
 Unreleased
 
+-   fix(pyproject): set project.license to the right value. :issue:`488`
 
 Version 3.0.2
 -------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,13 +3,12 @@ name = "MarkupSafe"
 version = "3.1.0.dev"
 description = "Safely add untrusted strings to HTML/XML markup."
 readme = "README.md"
-license = { file = "LICENSE.txt" }
+license = "BSD-3-Clause"
 maintainers = [{ name = "Pallets", email = "contact@palletsprojects.com" }]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Web Environment",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",


### PR DESCRIPTION
References: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license
Fixes: https://github.com/pallets/markupsafe/issues/488