### PR TITLE
Don't run pytest-run-parallel twice

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,7 +35,7 @@ jobs:
           python-version: ${{ matrix.python }}
           allow-prereleases: true
       - run: uv run --locked tox run -e ${{ matrix.tox || format('py{0}', matrix.python) }}
-      - if: endsWith(matrix.python, 't')
+      - if: ${{ matrix.python == '3.14t' }}
         run: uv run --locked tox run -e parallel
   typing:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Follow-up to #507.
Do not run the 'parallel' tox environment (which is hardcoded to 3.14t) twice unnecessarily:
- once on the 3.13t CI job (but it runs python 3.14t)
- once on the 3.14t CI job