### PR TITLE
feat: Build armv7l wheels

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -52,9 +52,9 @@ jobs:
         if: runner.os == 'Linux'
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         with:
-          platforms: arm64,riscv64
+          platforms: arm64,armv7l,riscv64
       - run: echo "SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)" >> $GITHUB_ENV
-      - uses: pypa/cibuildwheel@7c619efba910c04005a835b110b057fc28fd6e93 # v3.2.0
+      - uses: pypa/cibuildwheel@298ed2fb2c105540f5ed055e8a6ad78d82dd3a7e # v3.3.1
         env:
           # For workflow_dispatch, only build the new Python version.
           CIBW_BUILD: ${{ inputs.python && format('{0}-*', inputs.python) || null }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,7 +213,7 @@ select = "*-musllinux_riscv64"
 build-frontend = "build"
 
 [tool.cibuildwheel.linux]
-archs = ["x86_64", "aarch64", "riscv64"]
+archs = ["x86_64", "aarch64", "armv7l", "riscv64"]
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]


### PR DESCRIPTION
This PR adds so manylinux wheels are built for armv7l

This is now supported since cibuildwheel 3.3.0: https://github.com/pypa/cibuildwheel/releases/tag/v3.3.0
