### PR TITLE
Add Android and iOS wheels

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -36,12 +36,22 @@ jobs:
         # be present in the run for the hash job, so only the upload is skipped.
         if: github.event_name == 'push'
   wheels:
-    name: wheels / ${{ matrix.os }}
+    name: wheels / ${{ matrix.platform }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - platform: linux
+            os: ubuntu-latest
+          - platform: windows
+            os: windows-latest
+          - platform: macos
+            os: macos-latest
+          - platform: ios
+            os: macos-latest
+          - platform: android
+            os: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4 # v6.7.0
@@ -58,9 +68,10 @@ jobs:
         env:
           # For workflow_dispatch, only build the new Python version.
           CIBW_BUILD: ${{ inputs.python && format('{0}-*', inputs.python) || null }}
+          CIBW_PLATFORM: "${{ matrix.platform }}"
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: build-wheels-${{ matrix.os }}
+          name: build-wheels-${{ matrix.platform }}
           path: ./wheelhouse
   create-release:
     needs: [sdist, wheels]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Unreleased
 
 -   Drop support for Python 3.9.
 -   Remove previously deprecated code.
+-   Build Android wheels. :issue:`515`
+-   Build iOS wheels. :issue:`515`
 
 
 Version 3.0.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,3 +220,11 @@ archs = ["x86_64", "arm64"]
 
 [tool.cibuildwheel.windows]
 archs = ["auto", "ARM64"]
+
+[tool.cibuildwheel.ios]
+archs = ["arm64_iphoneos", "arm64_iphonesimulator", "x86_64_iphonesimulator"]
+build-frontend = "build"
+
+[tool.cibuildwheel.android]
+archs = ["arm64_v8a", "x86_64"]
+build-frontend = "build"


### PR DESCRIPTION
This PR adds Android and iOS wheels for Python 3.13 and 3.14 (the only versions with official supported for Android and iOS).
<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. An issue is not required for fixing typos in
documentation, or other simple non-code changes.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

fixes #515
<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.

fixes #<issue number>
-->

<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
