### PR TITLE
Added ppc64le wheels support

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -52,7 +52,7 @@ jobs:
         if: runner.os == 'Linux'
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         with:
-          platforms: arm64,riscv64
+          platforms: arm64,riscv64,ppc64le
       - run: echo "SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)" >> $GITHUB_ENV
       - uses: pypa/cibuildwheel@7c619efba910c04005a835b110b057fc28fd6e93 # v3.2.0
         env:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Unreleased
 
 -   Drop support for Python 3.9.
 -   Remove previously deprecated code.
-
+-   Build ppc64le wheels. :issue:`517`
 
 Version 3.0.3
 -------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,8 +212,12 @@ select = "*-musllinux_riscv64"
 # uv is not available
 build-frontend = "build"
 
+[[tool.cibuildwheel.overrides]]
+select = "*-musllinux_ppc64le"
+build-frontend = "build"
+
 [tool.cibuildwheel.linux]
-archs = ["x86_64", "aarch64", "riscv64"]
+archs = ["x86_64", "aarch64", "riscv64", "ppc64le"]
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]


### PR DESCRIPTION
Hi Team,

We would like to propose enabling CI support for the ppc64le (IBM Power) architecture in this repository as part of a broader effort to improve cross-platform compatibility within the scientific Python ecosystem.

Issue: https://github.com/pallets/markupsafe/issues/517