### PR TITLE
Improve benchmark script's output, fix wrong case, and make easier to run

### DIFF
--- a/bench.py
+++ b/bench.py
@@ -5,12 +5,9 @@
 #     "pyperf",
 # ]
 # ///
-import os
-import pathlib
 import subprocess
 import sys
 import tempfile
-
 
 with tempfile.TemporaryDirectory() as d:
     outfiles = []
@@ -23,7 +20,10 @@ with tempfile.TemporaryDirectory() as d:
             ("long escape", '"<strong>Hello, World!</strong>" * 1000'),
             ("short plain", '"Hello, World!"'),
             ("long plain", '"Hello, World!" * 1000'),
-            ("long prefix", '"Hello, World!" * 1000 + "<strong>Hello, World!</strong>"'),
+            (
+                "long prefix",
+                '"Hello, World!" * 1000 + "<strong>Hello, World!</strong>"',
+            ),
             ("long suffix", '"<strong>Hello, World!</strong>" + "x" * 100_000'),
         ):
             subprocess.run(
@@ -49,14 +49,16 @@ with tempfile.TemporaryDirectory() as d:
                 ],
                 stdout=subprocess.DEVNULL,
             )
-            print('.', end='', flush=True)
+            print(".", end="", flush=True)
         print()
 
-    subprocess.run([
-        sys.executable,
-        '-m',
-        'pyperf',
-        'compare_to',
-        '--table',
-        *outfiles,
-    ])
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pyperf",
+            "compare_to",
+            "--table",
+            *outfiles,
+        ]
+    )

--- a/bench.py
+++ b/bench.py
@@ -1,30 +1,62 @@
+#!/usr/bin/env python3
+# /// scripts
+# dependencies = [
+#     ".",
+#     "pyperf",
+# ]
+# ///
+import os
+import pathlib
 import subprocess
 import sys
+import tempfile
 
-for name, s in (
-    ("short escape", '"<strong>Hello, World!</strong>"'),
-    ("long escape", '"Hello, World!" * 1000'),
-    ("short plain", '"Hello, World!"'),
-    ("long plain", '"Hello, World!" * 1000'),
-    ("long suffix", '"<strong>Hello, World!</strong>" + "x" * 100_000'),
-):
+
+with tempfile.TemporaryDirectory() as d:
+    outfiles = []
     for mod in "native", "speedups":
-        subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "pyperf",
-                "timeit",
-                "--name",
-                f"{name} {mod}",
-                "-s",
-                (
-                    "import markupsafe\n"
-                    f"from markupsafe._{mod} import _escape_inner\n"
-                    "markupsafe._escape_inner = _escape_inner\n"
-                    "from markupsafe import escape\n"
-                    f"s = {s}"
-                ),
-                "escape(s)",
-            ]
-        )
+        print(mod, end="", flush=True)
+        outname = f"{d}/{mod}.json"
+        outfiles.append(outname)
+        for name, s in (
+            ("short escape", '"<strong>Hello, World!</strong>"'),
+            ("long escape", '"<strong>Hello, World!</strong>" * 1000'),
+            ("short plain", '"Hello, World!"'),
+            ("long plain", '"Hello, World!" * 1000'),
+            ("long prefix", '"Hello, World!" * 1000 + "<strong>Hello, World!</strong>"'),
+            ("long suffix", '"<strong>Hello, World!</strong>" + "x" * 100_000'),
+        ):
+            subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "pyperf",
+                    "timeit",
+                    "--quiet",
+                    "--name",
+                    name,
+                    "--append",
+                    outname,
+                    "-s",
+                    (
+                        "import markupsafe\n"
+                        f"from markupsafe._{mod} import _escape_inner\n"
+                        "markupsafe._escape_inner = _escape_inner\n"
+                        "from markupsafe import escape\n"
+                        f"s = {s}"
+                    ),
+                    "escape(s)",
+                ],
+                stdout=subprocess.DEVNULL,
+            )
+            print('.', end='', flush=True)
+        print()
+
+    subprocess.run([
+        sys.executable,
+        '-m',
+        'pyperf',
+        'compare_to',
+        '--table',
+        *outfiles,
+    ])


### PR DESCRIPTION
The "long escape" bench case is the same as "long plain", fix it to actually be a long escape. Also add a "long prefix" to match the "long suffix", and bench prefix galloping modes (if any).

The benchmark script requires pyperf, which is not in any of markupsafe's dependency groups, making it more complicated to run than necessary. By using a PEP 723 dependencies spec, `uv run bench.py` (or other PEP 723 runners) should work out of the box.

Because the script just prints the results to stdout it's annoying to compare results between implementations, especially when getting stability warnings. By storing the benchmarks into results files, then using `compare_to` to compare them, we get the same data (kinda, it doesn't print the jitter in table form) which makes things much easier to compare. This requires touching up the naming a bit so `compare_to` can line up the benches for comparison, but that does not seem detrimental.

Currently the output is fixed to the default table output which I think is the most convenient, but the script could take a parameter to influence that.

And if surfacing benchmark (in)stability is considered important, `pyperf check` could be run on the benchmark data before printing the results. Dumping the suite files to a non-temp directory (and not deleting them) could also be an option (probably opt-in via a script arg), especially to compare baselines with optimisations (#519).

fixes #523