### PR TITLE
AI junk

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ Markup('&lt;script&gt;alert(document.cookie);&lt;/script&gt;')
 
 >>> # wrap in Markup to mark text "safe" and prevent escaping
 >>> Markup("<strong>Hello</strong>")
-Markup('<strong>hello</strong>')
+Markup('<strong>Hello</strong>')
 
 >>> escape(Markup("<strong>Hello</strong>"))
-Markup('<strong>hello</strong>')
+Markup('<strong>Hello</strong>')
 
 >>> # Markup is a str subclass
 >>> # methods and operators escape their arguments

--- a/docs/html.rst
+++ b/docs/html.rst
@@ -46,4 +46,4 @@ should still be escaped:
 
     >>> user = User(3, "<script>")
     >>> escape(user)
-    Markup('<a href="/users/3">&lt;script&gt;</a>')
+    Markup('<a href="/user/3">&lt;script&gt;</a>')


### PR DESCRIPTION
## Summary
Two small doc example fixes where the shown output didn't match what the code actually produces:

- `README.md`: `Markup("<strong>Hello</strong>")` does not change case (confirmed in `Markup.__new__`), but the example output showed `hello` (lowercase) instead of `Hello`.
- `docs/html.rst`: the `User.__html__` example builds a `/user/{id}` URL (singular), but the shown output used `/users/{id}` (plural), which doesn't match.

## Test plan
- Docs-only change, no code behavior affected.
- Verified by reading `src/markupsafe/__init__.py` (`Markup.__new__`) to confirm no case transformation occurs.
- Verified the `/user/` vs `/users/` mismatch by comparing the example's `__html__` method body against its printed output.